### PR TITLE
operator: Use external asset contents instead of internal assets

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -35,13 +35,8 @@ type OperatorExtension interface {
 	Units() ([]UnitAsset, error)
 }
 
-func RenderAssetContent(assetPath string, params interface{}) ([]string, error) {
-	rawContent, err := Asset(assetPath)
-	if err != nil {
-		return nil, err
-	}
-
-	tmpl, err := template.New(assetPath).Parse(string(rawContent[:]))
+func RenderAssetContent(rawAssetContent []byte, params interface{}) ([]string, error) {
+	tmpl, err := template.New("").Parse(string(rawAssetContent[:]))
 	if err != nil {
 		return nil, err
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -24,7 +24,12 @@ func TestRenderAssetContent(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		content, err := RenderAssetContent(tc.assetPath, tc.params)
+		rawAssetContent, err := Asset(tc.assetPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		content, err := RenderAssetContent(rawAssetContent, tc.params)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
External extensions implementes in operator repos (like aws-operator) will use their own templates, that's why we need to allow to template them here.