### PR TITLE
Use text/template, not html/template

### DIFF
--- a/cloudconfig.go
+++ b/cloudconfig.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"html/template"
+	"text/template"
 
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/node"

--- a/operator.go
+++ b/operator.go
@@ -2,8 +2,8 @@ package cloudconfig
 
 import (
 	"bytes"
-	"html/template"
 	"strings"
+	"text/template"
 )
 
 type FileMetadata struct {


### PR DESCRIPTION
If we use html/template, text will be escaped to make it safe.

This is not what we want, we're not dealing with html and it breaks
things like base64-encoded keys and such.