### PR TITLE
Makefile: don't remove newline at the end of templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ verify-go-bindata-installation:
 	@which go-bindata || go get -u github.com/jteeuwen/go-bindata/...
 
 update-bindata: verify-go-bindata-installation
-	find templates/ -type f -exec perl -i -pe "chomp if eof" {} \;
 	go-bindata -modtime 1 -mode 420 -pkg cloudconfig templates/...
 
 check:


### PR DESCRIPTION
This was done for aesthetics reasons, but it changes the templates every
time since most text editors add a newline at the end.

Also, with the new commit hook introduced in 882419ab6, it leaves a
dirty git worktree after the commit.

Just remove it since we don't care that much about an extra line in the
resulting cloudconfig.