### PR TITLE
templates: Run calico-node service after decrypt-tls-assets

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -586,8 +586,8 @@ coreos:
     content: |
       [Unit]
       Description=Calico per-host agent
-      Requires=etcd2.service
-      After=etcd2.service
+      Requires=etcd2.service decrypt-tls-assets.service
+      After=etcd2.service decrypt-tls-assets.service
       Wants=k8s-api-server.service k8s-controller-manager.service k8s-scheduler.service
       StartLimitIntervalSec=0
 
@@ -1152,8 +1152,8 @@ coreos:
     content: |
       [Unit]
       Description=calicoctl node
-      Requires=k8s-setup-network-env.service
-      After=k8s-setup-network-env.service
+      Requires=k8s-setup-network-env.service decrypt-tls-assets.service
+      After=k8s-setup-network-env.service decrypt-tls-assets.service
       Wants=k8s-proxy.service k8s-kubelet.service
 
       [Service]


### PR DESCRIPTION
Calico needs decrypted certificates to run successfully.