### PR TITLE
remove/disable etcd in worker nodes

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1089,8 +1089,9 @@ coreos:
     command: stop
     mask: true
   - name: etcd2.service
-    enable: true
-    command: start
+    enable: false
+    command: stop
+    mask: true
   - name: fleet.service
     command: stop
     mask: true


### PR DESCRIPTION
Based on https://github.com/giantswarm/k8s-vm/pull/152 we should do this in all cloud configs we have to maintain right now. 