### PR TITLE
added missing trailing quotes to unit file

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -477,7 +477,7 @@ coreos:
     - name: 10-giantswarm-extra-args.conf
       content: |
         [Service]
-        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=systemd {{.Cluster.Docker.Daemon.ExtraArgs}}
+        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=systemd {{.Cluster.Docker.Daemon.ExtraArgs}}"
   - name: k8s-setup-network-env.service
     enable: true
     command: start
@@ -1094,7 +1094,7 @@ coreos:
     - name: 10-giantswarm-extra-args.conf
       content: |
         [Service]
-        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=systemd {{.Cluster.Docker.Daemon.ExtraArgs}}
+        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=systemd {{.Cluster.Docker.Daemon.ExtraArgs}}"
   - name: k8s-setup-network-env.service
     enable: true
     command: start


### PR DESCRIPTION
This PR fixes the following issue we found. 

```
$ journalctl -b
...
Apr 24 15:34:24 ip-10-0-141-134.eu-west-1.compute.internal systemd[1]: [/etc/systemd/system/docker.service.d/10-giantswarm-extra-args.conf:2] Trailing garbage, ignoring.
...
```