### PR TITLE
Moves extension units to top of cloudconfig

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -455,6 +455,12 @@ write_files:
 
 coreos:
   units:
+  {{range .Units}}- name: {{.Metadata.Name}}
+    enable: {{.Metadata.Enable}}
+    command: {{.Metadata.Command}}
+    content: |
+      {{range .Content}}{{.}}
+      {{end}}{{end}}
   - name: set-ownership-etcd-data-dir.service
     enable: true
     command: start
@@ -942,12 +948,6 @@ coreos:
 
       [Install]
       WantedBy=multi-user.target
-  {{range .Units}}- name: {{.Metadata.Name}}
-    enable: {{.Metadata.Enable}}
-    command: {{.Metadata.Command}}
-    content: |
-      {{range .Content}}{{.}}
-      {{end}}{{end}}
   update:
     reboot-strategy: off
 `
@@ -1070,6 +1070,12 @@ write_files:
 
 coreos:
   units:
+  {{range .Units}}- name: {{.Metadata.Name}}
+    enable: {{.Metadata.Enable}}
+    command: {{.Metadata.Command}}
+    content: |
+      {{range .Content}}{{.}}
+      {{end}}{{end}}
   - name: update-engine.service
     enable: false
     command: stop
@@ -1379,12 +1385,6 @@ coreos:
 
       [Install]
       WantedBy=multi-user.target
-  {{range .Units}}- name: {{.Metadata.Name}}
-    enable: {{.Metadata.Enable}}
-    command: {{.Metadata.Command}}
-    content: |
-      {{range .Content}}{{.}}
-      {{end}}{{end}}
   update:
     reboot-strategy: off
 `


### PR DESCRIPTION
Towards https://github.com/giantswarm/aws-operator/issues/131

coreos-cloudinit starts unit sequentially, so the order of the
units needs to avoid deadlocks. In the case where the
aws-operator adds decrypt-tls-assets which is a requirement of
the later units, this causes a deadlock.

This changset moves the extension units to the top of the
cloudconfig, to avoid these deadlocks.