### PR TITLE
Removes etc-kubernetes-data-etcd.mount

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -468,7 +468,6 @@ coreos:
       [Unit]
       Description=Set ownership to etcd2 data dir
       Wants=network-online.target
-      After=etc-kubernetes-data-etcd.mount
 
       [Service]
       Type=oneshot


### PR DESCRIPTION
Fixes https://github.com/giantswarm/k8scloudconfig/issues/61

This mount is legacy from the older platform, and is not actually
defined anywhere. Cleaning up a little.