### PR TITLE
Moves addons to require apiserver, instead of scheduler

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -860,8 +860,8 @@ coreos:
     content: |
       [Unit]
       Description=Kubernetes Addons
-      Wants=k8s-scheduler.service
-      After=k8s-scheduler.service
+      Wants=k8s-api-server.service
+      After=k8s-api-server.service
       [Service]
       Type=oneshot
       EnvironmentFile=/etc/network-environment


### PR DESCRIPTION
Fixes https://github.com/giantswarm/k8scloudconfig/issues/62

The addons script posts manifests to the apiserver, and has no
dependency on the scheduler. It makes more logical sense to have
it depend on the apiserver, instead of the scheduler.