### PR TITLE
provide double quotes for hostnames to prevent missing value

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -2,7 +2,7 @@ package cloudconfig
 
 const (
 	MasterTemplate = `#cloud-config
-hostname: {{.Node.Hostname}}
+hostname: "{{.Node.Hostname}}"
 write_files:
 - path: /etc/resolv.conf
   permissions: 0644
@@ -952,7 +952,7 @@ coreos:
 `
 
 	WorkerTemplate = `#cloud-config
-hostname: {{.Node.Hostname}}
+hostname: "{{.Node.Hostname}}"
 write_files:
 - path: /srv/10-calico.conf
   owner: root


### PR DESCRIPTION
In case the hostname is not properly set, then there is no hostname, which renders the yaml invalid. Having it wrapped in quotes keeps the yaml valid even if there is no hostname defined. 