### PR TITLE
Fix indent problem with multiple units

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -463,7 +463,8 @@ write_files:
 
 coreos:
   units:
-  {{range .Units}}- name: {{.Metadata.Name}}
+  {{range .Units}}
+  - name: {{.Metadata.Name}}
     enable: {{.Metadata.Enable}}
     command: {{.Metadata.Command}}
     content: |


### PR DESCRIPTION
Fixes indentation problem when rendering a 2nd operator unit in the main cloudconfig.