### PR TITLE
Use service account key pair in apiserver and controller-manager

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -725,7 +725,7 @@ coreos:
       --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-key-file=/etc/kubernetes/secrets/token_sign_key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-api-server-restart.service
@@ -787,7 +787,7 @@ coreos:
       --v=2 \
       --kubeconfig=/etc/kubernetes/config/controller-manager-kubeconfig.yml \
       --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-private-key-file=/etc/kubernetes/secrets/token_sign_key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager-restart.service


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388 and #70 

Use service account key pair in apiserver and controller-manager units. The aws-operator also needs to be extended to watch for the secret and download and decrypt it.
