### PR TITLE
Service account

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -1,16 +1,19 @@
 package cloudconfig
 
 type CompactTLSAssets struct {
-	APIServerCA     string
-	APIServerKey    string
-	APIServerCrt    string
-	WorkerCA        string
-	WorkerKey       string
-	WorkerCrt       string
-	CalicoClientCA  string
-	CalicoClientKey string
-	CalicoClientCrt string
-	EtcdServerCA    string
-	EtcdServerKey   string
-	EtcdServerCrt   string
+	APIServerCA       string
+	APIServerKey      string
+	APIServerCrt      string
+	WorkerCA          string
+	WorkerKey         string
+	WorkerCrt         string
+	ServiceAccountCA  string
+	ServiceAccountKey string
+	ServiceAccountCrt string
+	CalicoClientCA    string
+	CalicoClientKey   string
+	CalicoClientCrt   string
+	EtcdServerCA      string
+	EtcdServerKey     string
+	EtcdServerCrt     string
 }

--- a/templates.go
+++ b/templates.go
@@ -725,7 +725,7 @@ coreos:
       --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-key-file=/etc/kubernetes/secrets/token_sign_key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-api-server-restart.service
@@ -787,7 +787,7 @@ coreos:
       --v=2 \
       --kubeconfig=/etc/kubernetes/config/controller-manager-kubeconfig.yml \
       --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-private-key-file=/etc/kubernetes/secrets/token_sign_key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager-restart.service

--- a/templates.go
+++ b/templates.go
@@ -429,6 +429,18 @@ write_files:
   encoding: gzip+base64
   content: {{.TLSAssets.APIServerKey}}
 
+- path: /etc/kubernetes/ssl/service-account-crt.pem.enc
+  encoding: gzip+base64
+  content: {{.TLSAssets.ServiceAccountCrt}}
+
+- path: /etc/kubernetes/ssl/service-account-ca.pem.enc
+  encoding: gzip+base64
+  content: {{.TLSAssets.ServiceAccountCA}}
+
+- path: /etc/kubernetes/ssl/service-account-key.pem.enc
+  encoding: gzip+base64
+  content: {{.TLSAssets.ServiceAccountKey}}
+
 - path: /etc/kubernetes/ssl/calico/client-crt.pem.enc
   encoding: gzip+base64
   content: {{.TLSAssets.CalicoClientCrt}}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388 and fixes #70 

This PR adds service account to the TLS assets and creates the encoded files in the master cloudconfig.