### PR TITLE
Fix indent error when writing operator units in the worker template

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1112,7 +1112,8 @@ write_files:
 
 coreos:
   units:
-  {{range .Units}}- name: {{.Metadata.Name}}
+  {{range .Units}}
+  - name: {{.Metadata.Name}}
     enable: {{.Metadata.Enable}}
     command: {{.Metadata.Command}}
     content: |


### PR DESCRIPTION
Towards #81 

The decrypt unit isn't being written correctly due to this indent error. I've now checked the templates for all instances of this bug and this is the last one.