### PR TITLE
Rename etcd certs to client on the worker

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1090,15 +1090,15 @@ write_files:
   encoding: gzip+base64
   content: {{.TLSAssets.CalicoClientKey}}
 
-- path: /etc/kubernetes/ssl/etcd/server-crt.pem.enc
+- path: /etc/kubernetes/ssl/etcd/client-crt.pem.enc
   encoding: gzip+base64
   content: {{.TLSAssets.EtcdServerCrt}}
 
-- path: /etc/kubernetes/ssl/etcd/server-ca.pem.enc
+- path: /etc/kubernetes/ssl/etcd/client-ca.pem.enc
   encoding: gzip+base64
   content: {{.TLSAssets.EtcdServerCA}}
 
-- path: /etc/kubernetes/ssl/etcd/server-key.pem.enc
+- path: /etc/kubernetes/ssl/etcd/client-key.pem.enc
   encoding: gzip+base64
   content: {{.TLSAssets.EtcdServerKey}}
 


### PR DESCRIPTION
Fixes #87

The etcd certs are named incorrectly in the worker template. They've been renamed to client as a short term solution to unblock AWS testing. 

See #80 we need to move the certificate files to aws-operator as they are AWS specific. We will also eventually need to generate a separate client cert for the workers.