### PR TITLE
Use client cert when connecting to etcd

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -923,7 +923,11 @@ coreos:
       ExecStartPre=-/usr/bin/docker rm -f $NAME
       ExecStart=/usr/bin/docker run --rm --net=host \
       --name $NAME \
+      -v /etc/kubernetes/ssl/calico/:/etc/kubernetes/ssl/calico/ \
       -e ETCD_ENDPOINTS=https://{{ .Cluster.Etcd.Domain }}:2379 \
+      -e ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/calico/client-ca.pem \
+      -e ETCD_CERT_FILE=/etc/kubernetes/ssl/calico/client-crt.pem \
+      -e ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/client-key.pem \
       -e K8S_API=http://localhost:{{.Cluster.Kubernetes.API.InsecurePort}} \
       -e LEADER_ELECTION=true \
       $IMAGE


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388

This PR fixes a problem with the Calico policy controller not starting. The client cert needs to be provided when connecting to etcd.