### PR TITLE
Fix healthcheck port for liveness and readiness probes

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -287,13 +287,13 @@ write_files:
             readinessProbe:
               httpGet:
                 path: /healthz
-                port: 80
+                port: 10254
               initialDelaySeconds: 30
               timeoutSeconds: 1
             livenessProbe:
               httpGet:
                 path: /healthz
-                port: 80
+                port: 10254
               initialDelaySeconds: 30
               timeoutSeconds: 1
 - path: /srv/ingress-controller-svc.yml


### PR DESCRIPTION
Towards giantswarm/giantswarm#1381

IC pods were crashing because we were using the wrong healthcheck ports for the docker image we're using.