### PR TITLE
remove domains requirement from etcd2

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -499,8 +499,8 @@ coreos:
     content: |
       [Unit]
       Description=etcd2
-      Requires=wait-for-domains.service k8s-setup-network-env.service
-      After=wait-for-domains.service k8s-setup-network-env.service
+      Requires=k8s-setup-network-env.service
+      After=k8s-setup-network-env.service
       Conflicts=etcd.service
       Wants=calico-node.service
       StartLimitIntervalSec=0


### PR DESCRIPTION
etcd doesn't need the DNS records to be present. it's etcd's clients who need it, like calico-node.