### PR TITLE
extensions: Add "encoding" field to file metadata

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -6,10 +6,26 @@ import (
 	"text/template"
 )
 
+type encoding string
+
+const (
+	UTF8       encoding = "utf-8"
+	GzipBase64 encoding = "gzip+base64"
+)
+
+func (e encoding) String() string {
+	if e == "" {
+		return string(UTF8)
+	}
+
+	return string(e)
+}
+
 type FileMetadata struct {
 	AssetContent string
 	Path         string
 	Owner        string
+	Encoding     encoding
 	Permissions  int
 }
 

--- a/operator_test.go
+++ b/operator_test.go
@@ -10,6 +10,26 @@ type FakeParams struct {
 	Foo string
 }
 
+func TestEncodingType(t *testing.T) {
+	tests := []struct {
+		encodingInstance encoding
+		expectedString   string
+	}{
+		{
+			encodingInstance: encoding(""),
+			expectedString:   "utf-8",
+		},
+		{
+			encodingInstance: encoding("gzip+base64"),
+			expectedString:   "gzip+base64",
+		},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.expectedString, tc.encodingInstance.String(), "encoding type returned inappropriate string")
+	}
+}
+
 func TestRenderAssetContent(t *testing.T) {
 	tests := []struct {
 		assetContent    string

--- a/templates.go
+++ b/templates.go
@@ -421,6 +421,7 @@ write_files:
 {{range .Files}}
 - path: {{.Metadata.Path}}
   owner: {{.Metadata.Owner}}
+  encoding: {{.Metadata.Encoding}}
   permissions: {{printf "%#o" .Metadata.Permissions}}
   content: |
     {{range .Content}}{{.}}
@@ -1027,6 +1028,7 @@ write_files:
 {{range .Files}}
 - path: {{.Metadata.Path}}
   owner: {{.Metadata.Owner}}
+  encoding: {{.Metadata.Encoding}}
   permissions: {{printf "%#o" .Metadata.Permissions}}
   content: |
     {{range .Content}}{{.}}


### PR DESCRIPTION
TLS assets need to use gzip+base64 encoding, so we need to allow to specify encoding by extensions.

Ref #80