### PR TITLE
No encoding key if value is default (utf-8)

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -6,26 +6,15 @@ import (
 	"text/template"
 )
 
-type encoding string
-
 const (
-	UTF8       encoding = "utf-8"
-	GzipBase64 encoding = "gzip+base64"
+	GzipBase64 string = "gzip+base64"
 )
-
-func (e encoding) String() string {
-	if e == "" {
-		return string(UTF8)
-	}
-
-	return string(e)
-}
 
 type FileMetadata struct {
 	AssetContent string
 	Path         string
 	Owner        string
-	Encoding     encoding
+	Encoding     string
 	Permissions  int
 }
 

--- a/operator_test.go
+++ b/operator_test.go
@@ -10,26 +10,6 @@ type FakeParams struct {
 	Foo string
 }
 
-func TestEncodingType(t *testing.T) {
-	tests := []struct {
-		encodingInstance encoding
-		expectedString   string
-	}{
-		{
-			encodingInstance: encoding(""),
-			expectedString:   "utf-8",
-		},
-		{
-			encodingInstance: encoding("gzip+base64"),
-			expectedString:   "gzip+base64",
-		},
-	}
-
-	for _, tc := range tests {
-		assert.Equal(t, tc.expectedString, tc.encodingInstance.String(), "encoding type returned inappropriate string")
-	}
-}
-
 func TestRenderAssetContent(t *testing.T) {
 	tests := []struct {
 		assetContent    string

--- a/templates.go
+++ b/templates.go
@@ -437,7 +437,9 @@ write_files:
 {{range .Files}}
 - path: {{.Metadata.Path}}
   owner: {{.Metadata.Owner}}
+  {{ if .Metadata.Encoding }}
   encoding: {{.Metadata.Encoding}}
+  {{ end }}
   permissions: {{printf "%#o" .Metadata.Permissions}}
   content: |
     {{range .Content}}{{.}}
@@ -1060,7 +1062,9 @@ write_files:
 {{range .Files}}
 - path: {{.Metadata.Path}}
   owner: {{.Metadata.Owner}}
+  {{ if .Metadata.Encoding }}
   encoding: {{.Metadata.Encoding}}
+  {{ end }}
   permissions: {{printf "%#o" .Metadata.Permissions}}
   content: |
     {{range .Content}}{{.}}


### PR DESCRIPTION
utf-8 is not one of the allowed values for the `encoding` key, because
it's the implicit default value.

This fixes the cloudconfig.

See https://github.com/coreos/coreos-cloudinit/blob/d9e03750a7985103b89aa44574bfe7929007ec20/config/file.go#L18