### PR TITLE
enable cloud configs in KVM

### DIFF
--- a/cloudconfig.go
+++ b/cloudconfig.go
@@ -10,7 +10,7 @@ import (
 	"github.com/giantswarm/clustertpr/node"
 )
 
-type CloudConfigTemplateParams struct {
+type Params struct {
 	Cluster clustertpr.Cluster
 	Node    node.Node
 	Files   []FileAsset
@@ -19,12 +19,12 @@ type CloudConfigTemplateParams struct {
 
 type CloudConfig struct {
 	config    string
-	extension OperatorExtension
-	params    CloudConfigTemplateParams
+	extension Extension
+	params    Params
 	template  string
 }
 
-func NewCloudConfig(template string, params CloudConfigTemplateParams, extension OperatorExtension) (*CloudConfig, error) {
+func NewCloudConfig(template string, params Params, extension Extension) (*CloudConfig, error) {
 	files, err := extension.Files()
 	if err != nil {
 		return nil, err

--- a/cloudconfig.go
+++ b/cloudconfig.go
@@ -70,3 +70,7 @@ func (c *CloudConfig) Base64() string {
 
 	return base64.StdEncoding.EncodeToString(b.Bytes())
 }
+
+func (c *CloudConfig) String() string {
+	return c.config
+}

--- a/cloudconfig_test.go
+++ b/cloudconfig_test.go
@@ -8,18 +8,18 @@ import (
 func TestCloudConfig(t *testing.T) {
 	tests := []struct {
 		template  string
-		params    CloudConfigTemplateParams
-		extension OperatorExtension
+		params    Params
+		extension Extension
 	}{
 		{
 			template:  MasterTemplate,
-			params:    CloudConfigTemplateParams{},
-			extension: &FakeOperatorExtension{},
+			params:    Params{},
+			extension: &FakeExtension{},
 		},
 		{
 			template:  WorkerTemplate,
-			params:    CloudConfigTemplateParams{},
-			extension: &FakeOperatorExtension{},
+			params:    Params{},
+			extension: &FakeExtension{},
 		},
 	}
 

--- a/fake_operator.go
+++ b/fake_operator.go
@@ -1,11 +1,11 @@
 package cloudconfig
 
-type FakeOperatorExtension struct{}
+type FakeExtension struct{}
 
-func (f *FakeOperatorExtension) Files() ([]FileAsset, error) {
+func (f *FakeExtension) Files() ([]FileAsset, error) {
 	return nil, nil
 }
 
-func (f *FakeOperatorExtension) Units() ([]UnitAsset, error) {
+func (f *FakeExtension) Units() ([]UnitAsset, error) {
 	return nil, nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 9b751a013a655d9853ad510d8e2fc690c856ac5f644cec8afcaf24280db0f6a9
-updated: 2017-05-04T18:21:12.685086107+02:00
+updated: 2017-05-19T15:49:07.826610779+02:00
 imports:
 - name: github.com/giantswarm/awstpr
-  version: 2c564633fbbe90f6607227761f2aecc7e575c8f7
+  version: 2a9b74f9462593e89ce05d88cacbd8aff433ce08
   subpackages:
   - aws
 - name: github.com/giantswarm/clustertpr
-  version: 81d44901ce63086368ddcf639dffd1c8b4344190
+  version: 978d75bd50744b23be1bc6370035e88f9c35447b
   subpackages:
   - calico
   - cluster
@@ -31,14 +31,14 @@ imports:
   - vault
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
   - assert

--- a/operator.go
+++ b/operator.go
@@ -35,7 +35,7 @@ type UnitAsset struct {
 	Content  []string
 }
 
-type OperatorExtension interface {
+type Extension interface {
 	Files() ([]FileAsset, error)
 	Units() ([]UnitAsset, error)
 }

--- a/templates.go
+++ b/templates.go
@@ -2,7 +2,6 @@ package cloudconfig
 
 const (
 	MasterTemplate = `#cloud-config
-hostname: "{{.Node.Hostname}}"
 write_files:
 - path: /srv/kubedns-dep.yaml
   owner: root
@@ -984,7 +983,6 @@ coreos:
 `
 
 	WorkerTemplate = `#cloud-config
-hostname: "{{.Node.Hostname}}"
 write_files:
 - path: /srv/10-calico.conf
   owner: root
@@ -1359,7 +1357,7 @@ coreos:
       --register-node=true \
       --allow-privileged=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
-      --node-labels="kubernetes.io/hostname={{.Node.Hostname}},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME

--- a/vendor/github.com/davecgh/go-spew/LICENSE
+++ b/vendor/github.com/davecgh/go-spew/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2012-2013 Dave Collins <dave@davec.name>
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/README.md
+++ b/vendor/github.com/davecgh/go-spew/README.md
@@ -1,10 +1,12 @@
 go-spew
 =======
 
-[![Build Status](https://travis-ci.org/davecgh/go-spew.png?branch=master)]
-(https://travis-ci.org/davecgh/go-spew) [![Coverage Status]
-(https://coveralls.io/repos/davecgh/go-spew/badge.png?branch=master)]
+[![Build Status](https://img.shields.io/travis/davecgh/go-spew.svg)]
+(https://travis-ci.org/davecgh/go-spew) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org) [![Coverage Status]
+(https://img.shields.io/coveralls/davecgh/go-spew.svg)]
 (https://coveralls.io/r/davecgh/go-spew?branch=master)
+
 
 Go-spew implements a deep pretty printer for Go data structures to aid in
 debugging.  A comprehensive suite of tests with 100% test coverage is provided
@@ -19,7 +21,7 @@ post about it
 
 ## Documentation
 
-[![GoDoc](https://godoc.org/github.com/davecgh/go-spew/spew?status.png)]
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/davecgh/go-spew/spew)
 
 Full `go doc` style documentation for the project can be viewed online without
@@ -160,6 +162,15 @@ options. See the ConfigState documentation for more details.
 	App Engine or with the "safe" build tag specified.
 	Pointer method invocation is enabled by default.
 
+* DisablePointerAddresses
+	DisablePointerAddresses specifies whether to disable the printing of
+	pointer addresses. This is useful when diffing data structures in tests.
+
+* DisableCapacities
+	DisableCapacities specifies whether to disable the printing of capacities
+	for arrays, slices, maps and channels. This is useful when diffing data
+	structures in tests.
+
 * ContinueOnMethod
 	Enables recursion into types after invoking error and Stringer interface
 	methods. Recursion after method invocation is disabled by default.
@@ -191,4 +202,4 @@ using the unsafe package.
 
 ## License
 
-Go-spew is licensed under the liberal ISC License.
+Go-spew is licensed under the [copyfree](http://copyfree.org) ISC License.

--- a/vendor/github.com/davecgh/go-spew/spew/bypass.go
+++ b/vendor/github.com/davecgh/go-spew/spew/bypass.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Dave Collins <dave@davec.name>
+// Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
 //
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/bypasssafe.go
+++ b/vendor/github.com/davecgh/go-spew/spew/bypasssafe.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Dave Collins <dave@davec.name>
+// Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
 //
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/common.go
+++ b/vendor/github.com/davecgh/go-spew/spew/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/common_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/common_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/config.go
+++ b/vendor/github.com/davecgh/go-spew/spew/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -66,6 +66,15 @@ type ConfigState struct {
 	// running in environments without access to the unsafe package such as
 	// Google App Engine or with the "safe" build tag specified.
 	DisablePointerMethods bool
+
+	// DisablePointerAddresses specifies whether to disable the printing of
+	// pointer addresses. This is useful when diffing data structures in tests.
+	DisablePointerAddresses bool
+
+	// DisableCapacities specifies whether to disable the printing of capacities
+	// for arrays, slices, maps and channels. This is useful when diffing
+	// data structures in tests.
+	DisableCapacities bool
 
 	// ContinueOnMethod specifies whether or not recursion should continue once
 	// a custom error or Stringer interface is invoked.  The default, false,

--- a/vendor/github.com/davecgh/go-spew/spew/doc.go
+++ b/vendor/github.com/davecgh/go-spew/spew/doc.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -90,6 +90,15 @@ The following configuration options are available:
 		Disables invocation of error and Stringer interface methods on types
 		which only accept pointer receivers from non-pointer variables.
 		Pointer method invocation is enabled by default.
+
+	* DisablePointerAddresses
+		DisablePointerAddresses specifies whether to disable the printing of
+		pointer addresses. This is useful when diffing data structures in tests.
+
+	* DisableCapacities
+		DisableCapacities specifies whether to disable the printing of
+		capacities for arrays, slices, maps and channels. This is useful when
+		diffing data structures in tests.
 
 	* ContinueOnMethod
 		Enables recursion into types after invoking error and Stringer interface

--- a/vendor/github.com/davecgh/go-spew/spew/dump.go
+++ b/vendor/github.com/davecgh/go-spew/spew/dump.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -129,7 +129,7 @@ func (d *dumpState) dumpPtr(v reflect.Value) {
 	d.w.Write(closeParenBytes)
 
 	// Display pointer information.
-	if len(pointerChain) > 0 {
+	if !d.cs.DisablePointerAddresses && len(pointerChain) > 0 {
 		d.w.Write(openParenBytes)
 		for i, addr := range pointerChain {
 			if i > 0 {
@@ -282,13 +282,13 @@ func (d *dumpState) dump(v reflect.Value) {
 	case reflect.Map, reflect.String:
 		valueLen = v.Len()
 	}
-	if valueLen != 0 || valueCap != 0 {
+	if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
 		d.w.Write(openParenBytes)
 		if valueLen != 0 {
 			d.w.Write(lenEqualsBytes)
 			printInt(d.w, int64(valueLen), 10)
 		}
-		if valueCap != 0 {
+		if !d.cs.DisableCapacities && valueCap != 0 {
 			if valueLen != 0 {
 				d.w.Write(spaceBytes)
 			}

--- a/vendor/github.com/davecgh/go-spew/spew/dump_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/dump_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -70,7 +70,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-// dumpTest is used to describe a test to be perfomed against the Dump method.
+// dumpTest is used to describe a test to be performed against the Dump method.
 type dumpTest struct {
 	in    interface{}
 	wants []string

--- a/vendor/github.com/davecgh/go-spew/spew/dumpcgo_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/dumpcgo_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 Dave Collins <dave@davec.name>
+// Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
 //
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/example_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/example_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/format.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/format_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -75,7 +75,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-// formatterTest is used to describe a test to be perfomed against NewFormatter.
+// formatterTest is used to describe a test to be performed against NewFormatter.
 type formatterTest struct {
 	format string
 	in     interface{}

--- a/vendor/github.com/davecgh/go-spew/spew/internal_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/internal_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/internalunsafe_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/internalunsafe_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 Dave Collins <dave@davec.name>
+// Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
 
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/spew.go
+++ b/vendor/github.com/davecgh/go-spew/spew/spew.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/spew_test.go
+++ b/vendor/github.com/davecgh/go-spew/spew/spew_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -130,11 +130,18 @@ func initSpewTests() {
 	scsNoPmethods := &spew.ConfigState{Indent: " ", DisablePointerMethods: true}
 	scsMaxDepth := &spew.ConfigState{Indent: " ", MaxDepth: 1}
 	scsContinue := &spew.ConfigState{Indent: " ", ContinueOnMethod: true}
+	scsNoPtrAddr := &spew.ConfigState{DisablePointerAddresses: true}
+	scsNoCap := &spew.ConfigState{DisableCapacities: true}
 
 	// Variables for tests on types which implement Stringer interface with and
 	// without a pointer receiver.
 	ts := stringer("test")
 	tps := pstringer("test")
+
+	type ptrTester struct {
+		s *struct{}
+	}
+	tptr := &ptrTester{s: &struct{}{}}
 
 	// depthTester is used to test max depth handling for structs, array, slices
 	// and maps.
@@ -192,6 +199,10 @@ func initSpewTests() {
 		{scsContinue, fCSFprint, "", te, "(error: 10) 10"},
 		{scsContinue, fCSFdump, "", te, "(spew_test.customError) " +
 			"(error: 10) 10\n"},
+		{scsNoPtrAddr, fCSFprint, "", tptr, "<*>{<*>{}}"},
+		{scsNoPtrAddr, fCSSdump, "", tptr, "(*spew_test.ptrTester)({\ns: (*struct {})({\n})\n})\n"},
+		{scsNoCap, fCSSdump, "", make([]string, 0, 10), "([]string) {\n}\n"},
+		{scsNoCap, fCSSdump, "", make([]string, 1, 10), "([]string) (len=1) {\n(string) \"\"\n}\n"},
 	}
 }
 

--- a/vendor/github.com/giantswarm/awstpr/kind.go
+++ b/vendor/github.com/giantswarm/awstpr/kind.go
@@ -3,4 +3,7 @@ package awstpr
 const (
 	// Kind is the TPR kind for awstpr resources.
 	Kind = "Aws"
+
+	// PluralKind is the plural TPR kind for use in resource URLs.
+	PluralKind = "awses"
 )

--- a/vendor/github.com/giantswarm/awstpr/version.go
+++ b/vendor/github.com/giantswarm/awstpr/version.go
@@ -2,5 +2,5 @@ package awstpr
 
 const (
 	// VersionV1 is the Kubernetes API version for v1 cluster resources.
-	VersionV1 = "aws.cluster.giantswarm.io/v1"
+	VersionV1 = "cluster.giantswarm.io/v1"
 )

--- a/vendor/github.com/giantswarm/clustertpr/node/node.go
+++ b/vendor/github.com/giantswarm/clustertpr/node/node.go
@@ -1,7 +1,7 @@
 package node
 
 type Node struct {
-	Hostname string `json:"hostname" yaml:"hostname"`
-	Memory   string `json:"memory" yaml:"memory"`
-	CPUs     int    `json:"cpus" yaml:"cpus"`
+	CPUs   int    `json:"cpus" yaml:"cpus"`
+	ID     string `json:"id" yaml:"id"`
+	Memory string `json:"memory" yaml:"memory"`
 }

--- a/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
+++ b/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
@@ -559,8 +559,12 @@ type UnifiedDiff struct {
 func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
-	w := func(format string, args ...interface{}) error {
+	wf := func(format string, args ...interface{}) error {
 		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		return err
+	}
+	ws := func(s string) error {
+		_, err := buf.WriteString(s)
 		return err
 	}
 
@@ -581,26 +585,28 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			if len(diff.ToDate) > 0 {
 				toDate = "\t" + diff.ToDate
 			}
-			err := w("--- %s%s%s", diff.FromFile, fromDate, diff.Eol)
-			if err != nil {
-				return err
-			}
-			err = w("+++ %s%s%s", diff.ToFile, toDate, diff.Eol)
-			if err != nil {
-				return err
+			if diff.FromFile != "" || diff.ToFile != "" {
+				err := wf("--- %s%s%s", diff.FromFile, fromDate, diff.Eol)
+				if err != nil {
+					return err
+				}
+				err = wf("+++ %s%s%s", diff.ToFile, toDate, diff.Eol)
+				if err != nil {
+					return err
+				}
 			}
 		}
 		first, last := g[0], g[len(g)-1]
 		range1 := formatRangeUnified(first.I1, last.I2)
 		range2 := formatRangeUnified(first.J1, last.J2)
-		if err := w("@@ -%s +%s @@%s", range1, range2, diff.Eol); err != nil {
+		if err := wf("@@ -%s +%s @@%s", range1, range2, diff.Eol); err != nil {
 			return err
 		}
 		for _, c := range g {
 			i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
 			if c.Tag == 'e' {
 				for _, line := range diff.A[i1:i2] {
-					if err := w(" " + line); err != nil {
+					if err := ws(" " + line); err != nil {
 						return err
 					}
 				}
@@ -608,14 +614,14 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			}
 			if c.Tag == 'r' || c.Tag == 'd' {
 				for _, line := range diff.A[i1:i2] {
-					if err := w("-" + line); err != nil {
+					if err := ws("-" + line); err != nil {
 						return err
 					}
 				}
 			}
 			if c.Tag == 'r' || c.Tag == 'i' {
 				for _, line := range diff.B[j1:j2] {
-					if err := w("+" + line); err != nil {
+					if err := ws("+" + line); err != nil {
 						return err
 					}
 				}
@@ -669,8 +675,14 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
 	var diffErr error
-	w := func(format string, args ...interface{}) {
+	wf := func(format string, args ...interface{}) {
 		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		if diffErr == nil && err != nil {
+			diffErr = err
+		}
+	}
+	ws := func(s string) {
+		_, err := buf.WriteString(s)
 		if diffErr == nil && err != nil {
 			diffErr = err
 		}
@@ -700,15 +712,17 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 			if len(diff.ToDate) > 0 {
 				toDate = "\t" + diff.ToDate
 			}
-			w("*** %s%s%s", diff.FromFile, fromDate, diff.Eol)
-			w("--- %s%s%s", diff.ToFile, toDate, diff.Eol)
+			if diff.FromFile != "" || diff.ToFile != "" {
+				wf("*** %s%s%s", diff.FromFile, fromDate, diff.Eol)
+				wf("--- %s%s%s", diff.ToFile, toDate, diff.Eol)
+			}
 		}
 
 		first, last := g[0], g[len(g)-1]
-		w("***************" + diff.Eol)
+		ws("***************" + diff.Eol)
 
 		range1 := formatRangeContext(first.I1, last.I2)
-		w("*** %s ****%s", range1, diff.Eol)
+		wf("*** %s ****%s", range1, diff.Eol)
 		for _, c := range g {
 			if c.Tag == 'r' || c.Tag == 'd' {
 				for _, cc := range g {
@@ -716,7 +730,7 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 						continue
 					}
 					for _, line := range diff.A[cc.I1:cc.I2] {
-						w(prefix[cc.Tag] + line)
+						ws(prefix[cc.Tag] + line)
 					}
 				}
 				break
@@ -724,7 +738,7 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 		}
 
 		range2 := formatRangeContext(first.J1, last.J2)
-		w("--- %s ----%s", range2, diff.Eol)
+		wf("--- %s ----%s", range2, diff.Eol)
 		for _, c := range g {
 			if c.Tag == 'r' || c.Tag == 'i' {
 				for _, cc := range g {
@@ -732,7 +746,7 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 						continue
 					}
 					for _, line := range diff.B[cc.J1:cc.J2] {
-						w(prefix[cc.Tag] + line)
+						ws(prefix[cc.Tag] + line)
 					}
 				}
 				break

--- a/vendor/github.com/pmezard/go-difflib/difflib/difflib_test.go
+++ b/vendor/github.com/pmezard/go-difflib/difflib/difflib_test.go
@@ -102,11 +102,12 @@ group
 	}
 }
 
-func ExampleGetUnifiedDiffString() {
+func ExampleGetUnifiedDiffCode() {
 	a := `one
 two
 three
-four`
+four
+fmt.Printf("%s,%T",a,b)`
 	b := `zero
 one
 three
@@ -121,16 +122,54 @@ four`
 		Context:  3,
 	}
 	result, _ := GetUnifiedDiffString(diff)
-	fmt.Printf(strings.Replace(result, "\t", " ", -1))
+	fmt.Println(strings.Replace(result, "\t", " ", -1))
 	// Output:
 	// --- Original 2005-01-26 23:30:50
 	// +++ Current 2010-04-02 10:20:52
-	// @@ -1,4 +1,4 @@
+	// @@ -1,5 +1,4 @@
 	// +zero
 	//  one
 	// -two
 	//  three
 	//  four
+	// -fmt.Printf("%s,%T",a,b)
+}
+
+func ExampleGetContextDiffCode() {
+	a := `one
+two
+three
+four
+fmt.Printf("%s,%T",a,b)`
+	b := `zero
+one
+tree
+four`
+	diff := ContextDiff{
+		A:        SplitLines(a),
+		B:        SplitLines(b),
+		FromFile: "Original",
+		ToFile:   "Current",
+		Context:  3,
+		Eol:      "\n",
+	}
+	result, _ := GetContextDiffString(diff)
+	fmt.Print(strings.Replace(result, "\t", " ", -1))
+	// Output:
+	// *** Original
+	// --- Current
+	// ***************
+	// *** 1,5 ****
+	//   one
+	// ! two
+	// ! three
+	//   four
+	// - fmt.Printf("%s,%T",a,b)
+	// --- 1,4 ----
+	// + zero
+	//   one
+	// ! tree
+	//   four
 }
 
 func ExampleGetContextDiffString() {
@@ -316,6 +355,41 @@ func TestOutputFormatNoTrailingTabOnEmptyFiledate(t *testing.T) {
 	cd, err := GetContextDiffString(ContextDiff(diff))
 	assertEqual(t, err, nil)
 	assertEqual(t, SplitLines(cd)[:2], []string{"*** Original\n", "--- Current\n"})
+}
+
+func TestOmitFilenames(t *testing.T) {
+	diff := UnifiedDiff{
+		A:   SplitLines("o\nn\ne\n"),
+		B:   SplitLines("t\nw\no\n"),
+		Eol: "\n",
+	}
+	ud, err := GetUnifiedDiffString(diff)
+	assertEqual(t, err, nil)
+	assertEqual(t, SplitLines(ud), []string{
+		"@@ -0,0 +1,2 @@\n",
+		"+t\n",
+		"+w\n",
+		"@@ -2,2 +3,0 @@\n",
+		"-n\n",
+		"-e\n",
+		"\n",
+	})
+
+	cd, err := GetContextDiffString(ContextDiff(diff))
+	assertEqual(t, err, nil)
+	assertEqual(t, SplitLines(cd), []string{
+		"***************\n",
+		"*** 0 ****\n",
+		"--- 1,2 ----\n",
+		"+ t\n",
+		"+ w\n",
+		"***************\n",
+		"*** 2,3 ****\n",
+		"- n\n",
+		"- e\n",
+		"--- 3 ----\n",
+		"\n",
+	})
 }
 
 func TestSplitLines(t *testing.T) {

--- a/vendor/github.com/stretchr/testify/Godeps/Godeps.json
+++ b/vendor/github.com/stretchr/testify/Godeps/Godeps.json
@@ -9,7 +9,7 @@
 		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
 			"Comment": "v1.0.0-3-g6d21280",
-			"Rev": "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
+			"Rev": "04cdfd42973bb9c8589fd6a731800cf222fde1a9"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -1,385 +1,350 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package assert
 
 import (
-
 	http "net/http"
 	url "net/url"
 	time "time"
 )
-
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
 	return Condition(a.t, comp, msgAndArgs...)
 }
 
-
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  a.Empty(obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 	return Empty(a.t, object, msgAndArgs...)
 }
 
-
 // Equal asserts that two objects are equal.
-// 
+//
 //    a.Equal(123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
-//   if assert.Error(t, err, "An error was expected") {
-// 	   assert.Equal(t, err, expectedError)
-//   }
-// 
+//   a.EqualError(err,  expectedErrorString, "An error was expected")
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
-
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.Error(err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
-
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
-
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
 	return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
 	return FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // False asserts that the specified value is false.
-// 
+//
 //    a.False(myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	return False(a.t, value, msgAndArgs...)
 }
 
-
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPError(a.t, handler, method, url, values)
 }
 
-
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPRedirect(a.t, handler, method, url, values)
 }
 
-
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPSuccess(a.t, handler, method, url, values)
 }
 
-
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
-
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
-
-// InEpsilonSlice is the same as InEpsilon, except it compares two slices.
-func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
-	return InEpsilonSlice(a.t, expected, actual, delta, msgAndArgs...)
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	return InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
 }
-
 
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
-
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    a.Len(mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	return Len(a.t, object, length, msgAndArgs...)
 }
 
-
 // Nil asserts that the specified object is nil.
-// 
+//
 //    a.Nil(err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	return Nil(a.t, object, msgAndArgs...)
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.NoError(err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	return NoError(a.t, err, msgAndArgs...)
 }
 
-
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
 
-
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    a.NotNil(err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotNil(a.t, object, msgAndArgs...)
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   a.NotPanics(func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return NotPanics(a.t, f, msgAndArgs...)
 }
 
-
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   a.Panics(func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return Panics(a.t, f, msgAndArgs...)
 }
 
-
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
 
-
 // True asserts that the specified value is true.
-// 
+//
 //    a.True(myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	return True(a.t, value, msgAndArgs...)
 }
 
-
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -18,10 +18,6 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-func init() {
-	spew.Config.SortKeys = true
-}
-
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
 	Errorf(format string, args ...interface{})
@@ -157,7 +153,7 @@ func getWhitespaceString() string {
 	parts := strings.Split(file, "/")
 	file = parts[len(parts)-1]
 
-	return strings.Repeat(" ", len(fmt.Sprintf("%s:%d:      ", file, line)))
+	return strings.Repeat(" ", len(fmt.Sprintf("%s:%d:        ", file, line)))
 
 }
 
@@ -174,22 +170,18 @@ func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
 	return ""
 }
 
-// Indents all lines of the message by appending a number of tabs to each line, in an output format compatible with Go's
-// test printing (see inner comment for specifics)
-func indentMessageLines(message string, tabs int) string {
+// Aligns the provided message so that all lines after the first line start at the same location as the first line.
+// Assumes that the first line starts at the correct location (after carriage return, tab, label, spacer and tab).
+// The longestLabelLen parameter specifies the length of the longest label in the output (required becaues this is the
+// basis on which the alignment occurs).
+func indentMessageLines(message string, longestLabelLen int) string {
 	outBuf := new(bytes.Buffer)
 
 	for i, scanner := 0, bufio.NewScanner(strings.NewReader(message)); scanner.Scan(); i++ {
+		// no need to align first line because it starts at the correct location (after the label)
 		if i != 0 {
-			outBuf.WriteRune('\n')
-		}
-		for ii := 0; ii < tabs; ii++ {
-			outBuf.WriteRune('\t')
-			// Bizarrely, all lines except the first need one fewer tabs prepended, so deliberately advance the counter
-			// by 1 prematurely.
-			if ii == 0 && i > 0 {
-				ii++
-			}
+			// append alignLen+1 spaces to align with "{{longestLabel}}:" before adding tab
+			outBuf.WriteString("\n\r\t" + strings.Repeat(" ", longestLabelLen +1) + "\t")
 		}
 		outBuf.WriteString(scanner.Text())
 	}
@@ -221,27 +213,47 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool 
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
-
-	message := messageFromMsgAndArgs(msgAndArgs...)
-
-	errorTrace := strings.Join(CallerInfo(), "\n\r\t\t\t")
-	if len(message) > 0 {
-		t.Errorf("\r%s\r\tError Trace:\t%s\n"+
-			"\r\tError:%s\n"+
-			"\r\tMessages:\t%s\n\r",
-			getWhitespaceString(),
-			errorTrace,
-			indentMessageLines(failureMessage, 2),
-			message)
-	} else {
-		t.Errorf("\r%s\r\tError Trace:\t%s\n"+
-			"\r\tError:%s\n\r",
-			getWhitespaceString(),
-			errorTrace,
-			indentMessageLines(failureMessage, 2))
+	content := []labeledContent{
+		{"Error Trace", strings.Join(CallerInfo(), "\n\r\t\t\t")},
+		{"Error", failureMessage},
 	}
 
+	message := messageFromMsgAndArgs(msgAndArgs...)
+	if len(message) > 0 {
+		content = append(content, labeledContent{"Messages", message})
+	}
+
+	t.Errorf("\r" + getWhitespaceString() + labeledOutput(content...))
+
 	return false
+}
+
+type labeledContent struct {
+	label string
+	content string
+}
+
+// labeledOutput returns a string consisting of the provided labeledContent. Each labeled output is appended in the following manner:
+//
+//   \r\t{{label}}:{{align_spaces}}\t{{content}}\n
+//
+// The initial carriage return is required to undo/erase any padding added by testing.T.Errorf. The "\t{{label}}:" is for the label.
+// If a label is shorter than the longest label provided, padding spaces are added to make all the labels match in length. Once this
+// alignment is achieved, "\t{{content}}\n" is added for the output.
+//
+// If the content of the labeledOutput contains line breaks, the subsequent lines are aligned so that they start at the same location as the first line.
+func labeledOutput(content ...labeledContent) string {
+	longestLabel := 0
+	for _, v := range content {
+		if len(v.label) > longestLabel {
+			longestLabel = len(v.label)
+		}
+	}
+	var output string
+	for _, v := range content {
+		output += "\r\t" + v.label + ":" + strings.Repeat(" ", longestLabel-len(v.label)) + "\t" + indentMessageLines(v.content, longestLabel) + "\n"
+	}
+	return output
 }
 
 // Implements asserts that an object is implemented by the specified interface.
@@ -274,13 +286,17 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 //    assert.Equal(t, 123, 123, "123 and 123 should be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if !ObjectsAreEqual(expected, actual) {
 		diff := diff(expected, actual)
 		expected, actual = formatUnequalValues(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: %s (expected)\n"+
-			"        != %s (actual)%s", expected, actual, diff), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Not equal: \n"+
+			"expected: %s\n"+
+			"received: %s%s", expected, actual, diff), msgAndArgs...)
 	}
 
 	return true
@@ -294,29 +310,13 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 // with the type name, and the value will be enclosed in parenthesis similar
 // to a type conversion in the Go grammar.
 func formatUnequalValues(expected, actual interface{}) (e string, a string) {
-	aType := reflect.TypeOf(expected)
-	bType := reflect.TypeOf(actual)
-
-	if aType != bType && isNumericType(aType) && isNumericType(bType) {
-		return fmt.Sprintf("%v(%#v)", aType, expected),
-			fmt.Sprintf("%v(%#v)", bType, actual)
+	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
+		return fmt.Sprintf("%T(%#v)", expected, expected),
+			fmt.Sprintf("%T(%#v)", actual, actual)
 	}
 
 	return fmt.Sprintf("%#v", expected),
 		fmt.Sprintf("%#v", actual)
-}
-
-func isNumericType(t reflect.Type) bool {
-	switch t.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return true
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return true
-	case reflect.Float32, reflect.Float64:
-		return true
-	}
-
-	return false
 }
 
 // EqualValues asserts that two objects are equal or convertable to the same types
@@ -328,8 +328,11 @@ func isNumericType(t reflect.Type) bool {
 func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if !ObjectsAreEqualValues(expected, actual) {
-		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)", expected, actual), msgAndArgs...)
+		diff := diff(expected, actual)
+		expected, actual = formatUnequalValues(expected, actual)
+		return Fail(t, fmt.Sprintf("Not equal: \n"+
+			"expected: %s\n"+
+			"received: %s%s", expected, actual, diff), msgAndArgs...)
 	}
 
 	return true
@@ -556,6 +559,9 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 //    assert.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if ObjectsAreEqual(expected, actual) {
@@ -882,7 +888,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	if err != nil {
-		return Fail(t, fmt.Sprintf("Received unexpected error %+v", err), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
 	}
 
 	return true
@@ -913,14 +919,18 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
-
-	message := messageFromMsgAndArgs(msgAndArgs...)
-	if !NotNil(t, theError, "An error is expected but got nil. %s", message) {
+	if !Error(t, theError, msgAndArgs...) {
 		return false
 	}
-	s := "An error with value \"%s\" is expected but got \"%s\". %s"
-	return Equal(t, errString, theError.Error(),
-		s, errString, theError.Error(), message)
+	expected := errString
+	actual := theError.Error()
+	// don't need to use deep equals here, we know they are both strings
+	if expected != actual {
+		return Fail(t, fmt.Sprintf("Error message not equal:\n"+
+			"expected: %q\n"+
+			"received: %q", expected, actual), msgAndArgs...)
+	}
+	return true
 }
 
 // matchRegexp return true if a specified regexp matches a string.
@@ -1035,8 +1045,8 @@ func diff(expected interface{}, actual interface{}) string {
 		return ""
 	}
 
-	e := spew.Sdump(expected)
-	a := spew.Sdump(actual)
+	e := spewConfig.Sdump(expected)
+	a := spewConfig.Sdump(actual)
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 		A:        difflib.SplitLines(e),
@@ -1049,4 +1059,11 @@ func diff(expected interface{}, actual interface{}) string {
 	})
 
 	return "\n\nDiff:\n" + diff
+}
+
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
 }

--- a/vendor/github.com/stretchr/testify/assert/assertions_test.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions_test.go
@@ -1,12 +1,16 @@
 package assert
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
 	"reflect"
 	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -192,7 +196,71 @@ func TestEqual(t *testing.T) {
 	if !Equal(mockT, uint64(123), uint64(123)) {
 		t.Error("Equal should return true")
 	}
+	if !Equal(mockT, &struct{}{}, &struct{}{}) {
+		t.Error("Equal should return true (pointer equality is based on equality of underlying value)")
+	}
+	var m map[string]interface{}
+	if Equal(mockT, m["bar"], "something") {
+		t.Error("Equal should return false")
+	}
+}
 
+// bufferT implements TestingT. Its implementation of Errorf writes the output that would be produced by
+// testing.T.Errorf to an internal bytes.Buffer.
+type bufferT struct {
+	buf bytes.Buffer
+}
+
+func (t *bufferT) Errorf(format string, args ...interface{}) {
+	// implementation of decorate is copied from testing.T
+	decorate := func(s string) string {
+		_, file, line, ok := runtime.Caller(3) // decorate + log + public function.
+		if ok {
+			// Truncate file name at last file name separator.
+			if index := strings.LastIndex(file, "/"); index >= 0 {
+				file = file[index+1:]
+			} else if index = strings.LastIndex(file, "\\"); index >= 0 {
+				file = file[index+1:]
+			}
+		} else {
+			file = "???"
+			line = 1
+		}
+		buf := new(bytes.Buffer)
+		// Every line is indented at least one tab.
+		buf.WriteByte('\t')
+		fmt.Fprintf(buf, "%s:%d: ", file, line)
+		lines := strings.Split(s, "\n")
+		if l := len(lines); l > 1 && lines[l-1] == "" {
+			lines = lines[:l-1]
+		}
+		for i, line := range lines {
+			if i > 0 {
+				// Second and subsequent lines are indented an extra tab.
+				buf.WriteString("\n\t\t")
+			}
+			buf.WriteString(line)
+		}
+		buf.WriteByte('\n')
+		return buf.String()
+	}
+	t.buf.WriteString(decorate(fmt.Sprintf(format, args...)))
+}
+
+func TestEqualFormatting(t *testing.T) {
+	for i, currCase := range []struct {
+		equalWant  string
+		equalGot   string
+		msgAndArgs []interface{}
+		want       string
+	}{
+		{equalWant: "want", equalGot: "got", want: "\tassertions.go:[0-9]+: \r                          \r\tError Trace:\t\n\t\t\r\tError:      \tNot equal: \n\t\t\r\t            \texpected: \"want\"\n\t\t\r\t            \treceived: \"got\"\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{"hello, %v!", "world"}, want: "\tassertions.go:[0-9]+: \r                          \r\tError Trace:\t\n\t\t\r\tError:      \tNot equal: \n\t\t\r\t            \texpected: \"want\"\n\t\t\r\t            \treceived: \"got\"\n\t\t\r\tMessages:   \thello, world!\n"},
+	} {
+		mockT := &bufferT{}
+		Equal(mockT, currCase.equalWant, currCase.equalGot, currCase.msgAndArgs...)
+		Regexp(t, regexp.MustCompile(currCase.want), mockT.buf.String(), "Case %d", i)
+	}
 }
 
 func TestFormatUnequalValues(t *testing.T) {
@@ -207,6 +275,10 @@ func TestFormatUnequalValues(t *testing.T) {
 	expected, actual = formatUnequalValues(int64(123), int32(123))
 	Equal(t, `int64(123)`, expected, "value should include type")
 	Equal(t, `int32(123)`, actual, "value should include type")
+
+	expected, actual = formatUnequalValues(int64(123), nil)
+	Equal(t, `int64(123)`, expected, "value should include type")
+	Equal(t, `<nil>(<nil>)`, actual, "value should include type")
 
 	type testStructType struct {
 		Val string
@@ -341,6 +413,9 @@ func TestNotEqual(t *testing.T) {
 		t.Error("NotEqual should return false")
 	}
 	if NotEqual(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
+		t.Error("NotEqual should return false")
+	}
+	if NotEqual(mockT, &struct{}{}, &struct{}{}) {
 		t.Error("NotEqual should return false")
 	}
 }

--- a/vendor/github.com/stretchr/testify/mock/mock.go
+++ b/vendor/github.com/stretchr/testify/mock/mock.go
@@ -15,10 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func inin() {
-	spew.Config.SortKeys = true
-}
-
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
 	Logf(format string, args ...interface{})
@@ -283,7 +279,7 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 	functionPath := runtime.FuncForPC(pc).Name()
 	//Next four lines are required to use GCCGO function naming conventions.
 	//For Ex:  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock
-	//uses inteface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
+	//uses interface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
 	//With GCCGO we need to remove interface information starting from pN<dd>.
 	re := regexp.MustCompile("\\.pN\\d+_")
 	if re.MatchString(functionPath) {
@@ -746,8 +742,8 @@ func diff(expected interface{}, actual interface{}) string {
 		return ""
 	}
 
-	e := spew.Sdump(expected)
-	a := spew.Sdump(actual)
+	e := spewConfig.Sdump(expected)
+	a := spewConfig.Sdump(actual)
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 		A:        difflib.SplitLines(e),
@@ -760,4 +756,11 @@ func diff(expected interface{}, actual interface{}) string {
 	})
 
 	return diff
+}
+
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
 }

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,464 +1,429 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package require
 
 import (
-
 	assert "github.com/stretchr/testify/assert"
 	http "net/http"
 	url "net/url"
 	time "time"
 )
 
-
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
-  if !assert.Condition(t, comp, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Condition(t, comp, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    assert.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
 //    assert.Contains(t, ["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    assert.Contains(t, {"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-  if !assert.Contains(t, s, contains, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Contains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  assert.Empty(t, obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.Empty(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Empty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Equal asserts that two objects are equal.
-// 
+//
 //    assert.Equal(t, 123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.Equal(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Equal(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
-//   if assert.Error(t, err, "An error was expected") {
-// 	   assert.Equal(t, err, expectedError)
-//   }
-// 
+//   assert.EqualError(t, err,  expectedErrorString, "An error was expected")
+//
 // Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
-  if !assert.EqualError(t, theError, errString, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    assert.EqualValues(t, uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
-  if !assert.Error(t, err, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Error(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    assert.Exactly(t, int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.Exactly(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
-  if !assert.Fail(t, failureMessage, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Fail(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // FailNow fails test
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
-  if !assert.FailNow(t, failureMessage, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.FailNow(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // False asserts that the specified value is false.
-// 
+//
 //    assert.False(t, myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
-  if !assert.False(t, value, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.False(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  assert.HTTPBodyContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
-  if !assert.HTTPBodyContains(t, handler, method, url, values, str) {
-    t.FailNow()
-  }
+	if !assert.HTTPBodyContains(t, handler, method, url, values, str) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  assert.HTTPBodyNotContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
-  if !assert.HTTPBodyNotContains(t, handler, method, url, values, str) {
-    t.FailNow()
-  }
+	if !assert.HTTPBodyNotContains(t, handler, method, url, values, str) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
-  if !assert.HTTPError(t, handler, method, url, values) {
-    t.FailNow()
-  }
+	if !assert.HTTPError(t, handler, method, url, values) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
-  if !assert.HTTPRedirect(t, handler, method, url, values) {
-    t.FailNow()
-  }
+	if !assert.HTTPRedirect(t, handler, method, url, values) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
-  if !assert.HTTPSuccess(t, handler, method, url, values) {
-    t.FailNow()
-  }
+	if !assert.HTTPSuccess(t, handler, method, url, values) {
+		t.FailNow()
+	}
 }
-
 
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject), "MyObject")
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-  if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-  if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
-  if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
-// InEpsilonSlice is the same as InEpsilon, except it compares two slices.
-func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-  if !assert.InEpsilonSlice(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.IsType(t, expectedType, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
-  if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    assert.Len(t, mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
-  if !assert.Len(t, object, length, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Nil asserts that the specified object is nil.
-// 
+//
 //    assert.Nil(t, err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.Nil(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Nil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.NoError(t, err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
-  if !assert.NoError(t, err, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    assert.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    assert.NotContains(t, ["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    assert.NotContains(t, {"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotContains(t, s, contains, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotContains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if assert.NotEmpty(t, obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotEmpty(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotEmpty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    assert.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    assert.NotNil(t, err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotNil(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotNil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   assert.NotPanics(t, func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-  if !assert.NotPanics(t, f, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotPanics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  assert.NotRegexp(t, "^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotZero(t, i, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotZero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   assert.Panics(t, func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-  if !assert.Panics(t, f, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Panics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  assert.Regexp(t, "start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
-  if !assert.Regexp(t, rx, str, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // True asserts that the specified value is true.
-// 
+//
 //    assert.True(t, myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
-  if !assert.True(t, value, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.True(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
-  if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
-  if !assert.Zero(t, i, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Zero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
 }

--- a/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,6 +1,6 @@
 {{.Comment}}
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
-  if !assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) {
-    t.FailNow()
-  }
+	if !assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) {
+		t.FailNow()
+	}
 }

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,386 +1,351 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package require
 
 import (
-
 	assert "github.com/stretchr/testify/assert"
 	http "net/http"
 	url "net/url"
 	time "time"
 )
 
-
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
 	Condition(a.t, comp, msgAndArgs...)
 }
 
-
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	Contains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  a.Empty(obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 	Empty(a.t, object, msgAndArgs...)
 }
 
-
 // Equal asserts that two objects are equal.
-// 
+//
 //    a.Equal(123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Equal(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
-//   if assert.Error(t, err, "An error was expected") {
-// 	   assert.Equal(t, err, expectedError)
-//   }
-// 
+//   a.EqualError(err,  expectedErrorString, "An error was expected")
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
 	EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
-
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.Error(err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	Error(a.t, err, msgAndArgs...)
 }
 
-
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Exactly(a.t, expected, actual, msgAndArgs...)
 }
-
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
 	Fail(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
 	FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // False asserts that the specified value is false.
-// 
+//
 //    a.False(myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 	False(a.t, value, msgAndArgs...)
 }
 
-
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
 	HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
 	HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) {
 	HTTPError(a.t, handler, method, url, values)
 }
 
-
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) {
 	HTTPRedirect(a.t, handler, method, url, values)
 }
 
-
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) {
 	HTTPSuccess(a.t, handler, method, url, values)
 }
 
-
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
-
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
-
-// InEpsilonSlice is the same as InEpsilon, except it compares two slices.
-func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-	InEpsilonSlice(a.t, expected, actual, delta, msgAndArgs...)
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
 }
-
 
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
-
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
 	JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    a.Len(mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
 	Len(a.t, object, length, msgAndArgs...)
 }
 
-
 // Nil asserts that the specified object is nil.
-// 
+//
 //    a.Nil(err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 	Nil(a.t, object, msgAndArgs...)
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.NoError(err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 	NoError(a.t, err, msgAndArgs...)
 }
 
-
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	NotContains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 	NotEmpty(a.t, object, msgAndArgs...)
 }
 
-
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    a.NotNil(err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 	NotNil(a.t, object, msgAndArgs...)
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   a.NotPanics(func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	NotPanics(a.t, f, msgAndArgs...)
 }
 
-
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	NotRegexp(a.t, rx, str, msgAndArgs...)
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
 	NotZero(a.t, i, msgAndArgs...)
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   a.Panics(func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	Panics(a.t, f, msgAndArgs...)
 }
 
-
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	Regexp(a.t, rx, str, msgAndArgs...)
 }
 
-
 // True asserts that the specified value is true.
-// 
+//
 //    a.True(myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 	True(a.t, value, msgAndArgs...)
 }
 
-
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {

--- a/vendor/github.com/stretchr/testify/suite/interfaces.go
+++ b/vendor/github.com/stretchr/testify/suite/interfaces.go
@@ -32,3 +32,15 @@ type TearDownAllSuite interface {
 type TearDownTestSuite interface {
 	TearDownTest()
 }
+
+// BeforeTest has a function to be executed right before the test
+// starts and receives the suite and test names as input
+type BeforeTest interface {
+	BeforeTest(suiteName, testName string)
+}
+
+// AfterTest has a function to be executed right after the test
+// finishes and receives the suite and test names as input
+type AfterTest interface {
+	AfterTest(suiteName, testName string)
+}

--- a/vendor/github.com/stretchr/testify/suite/suite.go
+++ b/vendor/github.com/stretchr/testify/suite/suite.go
@@ -86,7 +86,13 @@ func Run(t *testing.T, suite TestingSuite) {
 					if setupTestSuite, ok := suite.(SetupTestSuite); ok {
 						setupTestSuite.SetupTest()
 					}
+					if beforeTestSuite, ok := suite.(BeforeTest); ok {
+						beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
+					}
 					defer func() {
+						if afterTestSuite, ok := suite.(AfterTest); ok {
+							afterTestSuite.AfterTest(methodFinder.Elem().Name(), method.Name)
+						}
 						if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
 							tearDownTestSuite.TearDownTest()
 						}

--- a/vendor/github.com/stretchr/testify/suite/suite_test.go
+++ b/vendor/github.com/stretchr/testify/suite/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -58,6 +59,15 @@ type SuiteTester struct {
 	TestOneRunCount       int
 	TestTwoRunCount       int
 	NonTestMethodRunCount int
+
+	SuiteNameBefore []string
+	TestNameBefore  []string
+
+	SuiteNameAfter []string
+	TestNameAfter  []string
+
+	TimeBefore []time.Time
+	TimeAfter  []time.Time
 }
 
 type SuiteSkipTester struct {
@@ -73,6 +83,18 @@ type SuiteSkipTester struct {
 // start of the testing suite, before any tests are run.
 func (suite *SuiteTester) SetupSuite() {
 	suite.SetupSuiteRunCount++
+}
+
+func (suite *SuiteTester) BeforeTest(suiteName, testName string) {
+	suite.SuiteNameBefore = append(suite.SuiteNameBefore, suiteName)
+	suite.TestNameBefore = append(suite.TestNameBefore, testName)
+	suite.TimeBefore = append(suite.TimeBefore, time.Now())
+}
+
+func (suite *SuiteTester) AfterTest(suiteName, testName string) {
+	suite.SuiteNameAfter = append(suite.SuiteNameAfter, suiteName)
+	suite.TestNameAfter = append(suite.TestNameAfter, testName)
+	suite.TimeAfter = append(suite.TimeAfter, time.Now())
 }
 
 func (suite *SuiteSkipTester) SetupSuite() {
@@ -144,6 +166,35 @@ func TestRunSuite(t *testing.T) {
 	// methods should have each been run only once.
 	assert.Equal(t, suiteTester.SetupSuiteRunCount, 1)
 	assert.Equal(t, suiteTester.TearDownSuiteRunCount, 1)
+
+	assert.Equal(t, len(suiteTester.SuiteNameAfter), 3)
+	assert.Equal(t, len(suiteTester.SuiteNameBefore), 3)
+	assert.Equal(t, len(suiteTester.TestNameAfter), 3)
+	assert.Equal(t, len(suiteTester.TestNameBefore), 3)
+
+	assert.Contains(t, suiteTester.TestNameAfter, "TestOne")
+	assert.Contains(t, suiteTester.TestNameAfter, "TestTwo")
+	assert.Contains(t, suiteTester.TestNameAfter, "TestSkip")
+
+	assert.Contains(t, suiteTester.TestNameBefore, "TestOne")
+	assert.Contains(t, suiteTester.TestNameBefore, "TestTwo")
+	assert.Contains(t, suiteTester.TestNameBefore, "TestSkip")
+
+	for _, suiteName := range suiteTester.SuiteNameAfter {
+		assert.Equal(t, "SuiteTester", suiteName)
+	}
+
+	for _, suiteName := range suiteTester.SuiteNameBefore {
+		assert.Equal(t, "SuiteTester", suiteName)
+	}
+
+	for _, when := range suiteTester.TimeAfter {
+		assert.False(t, when.IsZero())
+	}
+
+	for _, when := range suiteTester.TimeBefore {
+		assert.False(t, when.IsZero())
+	}
 
 	// There are three test methods (TestOne, TestTwo, and TestSkip), so
 	// the SetupTest and TearDownTest methods (which should be run once for


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1197. I did several things here. Thanks for bearing with me. The PR is not that big though. 

- Updated vendor deps to get clustertpr changes for the hostname replacement. 
- Simplifying some variable naming. This is nicer from a client point of view. 
- Added a `String()` method to the cloud config. KVM does not expect the cloud config to be base64 encoded. 