### PR TITLE
remove unused calico environment file invocation

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -848,7 +848,6 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      EnvironmentFile=/etc/calico-environment
       Environment="ETCD_AUTHORITY={{ .Cluster.Etcd.Domain }}:2379"
       Environment="ETCD_SCHEME=https"
       Environment="ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/calico/client-ca.pem"
@@ -1402,7 +1401,6 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      EnvironmentFile=/etc/calico-environment
       Environment="ETCD_AUTHORITY={{ .Cluster.Etcd.Domain }}:2379"
       Environment="ETCD_SCHEME=https"
       Environment="ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/calico/client-ca.pem"


### PR DESCRIPTION
it was only there to support the $BRIDGE_IP hack, which was removed in #111