### PR TITLE
making calico hosted (and updating to latest)

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -310,7 +310,7 @@ write_files:
                   value: "true"
               volumeMounts:
                 # Mount in the etcd TLS secrets.
-                - mountPath: /etc/kubernetes/etcd
+                - mountPath: /etc/kubernetes/ssl/etcd
                   name: etcd-certs
           volumes:
             # Mount in the etcd TLS secrets.

--- a/templates.go
+++ b/templates.go
@@ -71,9 +71,9 @@ write_files:
             }
         }
     
-      etcd_ca: "/etc/kubernetes/etcd/etcd-ca.pem"
-      etcd_cert: "/etc/kubernetes/etcd/etcd.pem"
-      etcd_key: "/etc/kubernetes/etcd/etcd-key.pem"
+      etcd_ca: "/etc/kubernetes/ssl/etcd/etcd-ca.pem"
+      etcd_cert: "/etc/kubernetes/ssl/etcd/etcd.pem"
+      etcd_key: "/etc/kubernetes/ssl/etcd/etcd-key.pem"
     
 - path: /srv/calico-ds.yaml
   owner: root

--- a/templates.go
+++ b/templates.go
@@ -3,6 +3,320 @@ package cloudconfig
 const (
 	MasterTemplate = `#cloud-config
 write_files:
+- path: /srv/calico-policy-controller-sa.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+- path: /srv/calico-node-sa.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+- path: /srv/calico-configmap.yaml
+  owner: root
+  permissions: 644
+  content: |
+    # Calico Version v2.2.1
+    # http://docs.projectcalico.org/v2.2/releases#v2.2.1
+    # This manifest includes the following component versions:
+    #   calico/node:v1.2.1
+    #   calico/cni:v1.8.3
+    #   calico/kube-policy-controller:v0.6.0
+
+    # This ConfigMap is used to configure a self-hosted Calico installation.
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: calico-config
+      namespace: kube-system
+    data:
+      # Configure this with the location of your etcd cluster.
+      etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:2379"
+
+      # Configure the Calico backend to use.
+      calico_backend: "bird"
+    
+      # The CNI network configuration to install on each node.
+      # TODO: Do we still need to set MTU manually?
+      cni_network_config: |-
+        {
+            "name": "k8s-pod-network",
+            "cniVersion": "0.1.0",
+            "type": "calico",
+            "etcd_endpoints": "__ETCD_ENDPOINTS__",
+            "etcd_key_file": "__ETCD_KEY_FILE__",
+            "etcd_cert_file": "__ETCD_CERT_FILE__",
+            "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+            "log_level": "info",
+            "ipam": {
+                "type": "calico-ipam"
+            },
+            "mtu": {{.Cluster.Calico.MTU}},
+            "policy": {
+                "type": "k8s",
+                "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+            },
+            "kubernetes": {
+                "kubeconfig": "__KUBECONFIG_FILEPATH__"
+            }
+        }
+    
+      etcd_ca: "/etc/kubernetes/etcd/etcd-ca.pem"
+      etcd_cert: "/etc/kubernetes/etcd/etcd.pem"
+      etcd_key: "/etc/kubernetes/etcd/etcd-key.pem"
+    
+- path: /srv/calico-ds.yaml
+  owner: root
+  permissions: 644
+  content: |
+    
+    # This manifest installs the calico/node container, as well
+    # as the Calico CNI plugins and network config on
+    # each master and worker node in a Kubernetes cluster.
+    kind: DaemonSet
+    apiVersion: extensions/v1beta1
+    metadata:
+      name: calico-node
+      namespace: kube-system
+      labels:
+        k8s-app: calico-node
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+            scheduler.alpha.kubernetes.io/tolerations: |
+              [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+               {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+        spec:
+          hostNetwork: true
+          serviceAccountName: calico-node
+          containers:
+            # Runs calico/node container on each Kubernetes node.  This
+            # container programs network policy and routes on each
+            # host.
+            - name: calico-node
+              image: quay.io/calico/node:v1.2.1
+              env:
+                # The location of the Calico etcd cluster.
+                - name: ETCD_ENDPOINTS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_endpoints
+                # Choose the backend to use.
+                - name: CALICO_NETWORKING_BACKEND
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: calico_backend
+                # Disable file logging so `kubectl logs` works.
+                - name: CALICO_DISABLE_FILE_LOGGING
+                  value: "true"
+                # Set Felix endpoint to host default action to ACCEPT.
+                - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+                  value: "ACCEPT"
+                # Configure the IP Pool from which Pod IPs will be chosen.
+                - name: CALICO_IPV4POOL_CIDR
+                  value: "192.168.0.0/16"
+                - name: CALICO_IPV4POOL_IPIP
+                  value: "always"
+                # Disable IPv6 on Kubernetes.
+                - name: FELIX_IPV6SUPPORT
+                  value: "false"
+                # Set Felix logging to "info"
+                - name: FELIX_LOGSEVERITYSCREEN
+                  value: "info"
+                # Location of the CA certificate for etcd.
+                - name: ETCD_CA_CERT_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_ca
+                # Location of the client key for etcd.
+                - name: ETCD_KEY_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_key
+                # Location of the client certificate for etcd.
+                - name: ETCD_CERT_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_cert
+                # Auto-detect the BGP IP address.
+                - name: IP
+                  value: ""
+              securityContext:
+                privileged: true
+              resources:
+                requests:
+                  cpu: 250m
+              volumeMounts:
+                - mountPath: /lib/modules
+                  name: lib-modules
+                  readOnly: true
+                - mountPath: /var/run/calico
+                  name: var-run-calico
+                  readOnly: false
+                - mountPath: /etc/kubernetes/ssl/etcd
+                  name: etcd-certs
+            # This container installs the Calico CNI binaries
+            # and CNI network config file on each node.
+            - name: install-cni
+              image: quay.io/calico/cni:v1.8.3
+              command: ["/install-cni.sh"]
+              env:
+                # The location of the Calico etcd cluster.
+                - name: ETCD_ENDPOINTS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_endpoints
+                # The CNI network config to install on each node.
+                - name: CNI_NETWORK_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: cni_network_config
+                # Location of the CA certificate for etcd.
+                - name: CNI_CONF_ETCD_CA
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_ca
+                # Location of the client key for etcd.
+                - name: CNI_CONF_ETCD_KEY
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_key
+                # Location of the client certificate for etcd.
+                - name: CNI_CONF_ETCD_CERT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_cert
+              volumeMounts:
+                - mountPath: /host/opt/cni/bin
+                  name: cni-bin-dir
+                - mountPath: /host/etc/cni/net.d
+                  name: cni-net-dir
+                - mountPath: /etc/kubernetes/ssl/etcd
+                  name: etcd-certs
+          volumes:
+            # Used by calico/node.
+            - name: etcd-certs
+              hostPath:
+                path: /etc/kubernetes/ssl/etcd
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            - name: var-run-calico
+              hostPath:
+                path: /var/run/calico
+            - name: cni-bin-dir
+              hostPath:
+                path: /opt/cni/bin
+            - name: cni-net-dir
+              hostPath:
+               path: /etc/cni/net.d
+- path: /srv/calico-policy-controller.yaml
+  owner: root
+  permissions: 644
+  content: |
+    # This manifest deploys the Calico policy controller on Kubernetes.
+    # See https://github.com/projectcalico/k8s-policy
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # The policy controller can only have a single active instance.
+      replicas: 1
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          name: calico-policy-controller
+          namespace: kube-system
+          labels:
+            k8s-app: calico-policy
+        spec:
+          # The policy controller must run in the host network namespace so that
+          # it isn't governed by policy that would prevent it from working.
+          hostNetwork: true
+          serviceAccountName: calico-policy-controller
+          containers:
+            - name: calico-policy-controller
+              image: quay.io/calico/kube-policy-controller:v0.6.0
+              env:
+                # The location of the Calico etcd cluster.
+                - name: ETCD_ENDPOINTS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_endpoints
+                # Location of the CA certificate for etcd.
+                - name: ETCD_CA_CERT_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_ca
+                # Location of the client key for etcd.
+                - name: ETCD_KEY_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_key
+                # Location of the client certificate for etcd.
+                - name: ETCD_CERT_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_cert
+                # The location of the Kubernetes API.  Use the default Kubernetes
+                # service for API access.
+                - name: K8S_API
+                  value: "https://{{.Cluster.Kubernetes.API.Domain}}:443"
+                # Since we're running in the host namespace and might not have KubeDNS
+                # access, configure the container's /etc/hosts to resolve
+                # kubernetes.default to the correct service clusterIP.
+                - name: CONFIGURE_ETC_HOSTS
+                  value: "true"
+              volumeMounts:
+                # Mount in the etcd TLS secrets.
+                - mountPath: /etc/kubernetes/etcd
+                  name: etcd-certs
+          volumes:
+            # Mount in the etcd TLS secrets.
+            - name: etcd-certs
+              hostPath:
+                path: /etc/kubernetes/ssl/etcd
 - path: /srv/kubedns-dep.yaml
   owner: root
   permissions: 0644

--- a/templates.go
+++ b/templates.go
@@ -71,9 +71,9 @@ write_files:
             }
         }
     
-      etcd_ca: "/etc/kubernetes/ssl/etcd/etcd-ca.pem"
-      etcd_cert: "/etc/kubernetes/ssl/etcd/etcd.pem"
-      etcd_key: "/etc/kubernetes/ssl/etcd/etcd-key.pem"
+      etcd_ca: "/etc/kubernetes/ssl/etcd/client-ca.pem"
+      etcd_cert: "/etc/kubernetes/ssl/etcd/client-crt.pem"
+      etcd_key: "/etc/kubernetes/ssl/etcd/client-key.pem"
     
 - path: /srv/calico-ds.yaml
   owner: root

--- a/templates.go
+++ b/templates.go
@@ -125,7 +125,7 @@ write_files:
                     configMapKeyRef:
                       name: calico-config
                       key: calico_backend
-                # Disable file logging so `kubectl logs` works.
+                # Disable file logging so kubectl logs works.
                 - name: CALICO_DISABLE_FILE_LOGGING
                   value: "true"
                 # Set Felix endpoint to host default action to ACCEPT.


### PR DESCRIPTION
Towards https://github.com/giantswarm/k8scloudconfig/issues/40

WIP

Running Calico 2.2.1

This is already implemented and tested manually on `wopre` cluster on AWS FRA

TODO:
- [x] add calico yamls
- [x] check/rename etcd cert directory/filename
- [ ] test
- [ ] retag images