### PR TITLE
update etcd version

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -656,33 +656,6 @@ coreos:
 
       [Install]
       WantedBy=multi-user.target
-  - name: etcd3-restart.service
-    enable: true
-    content: |
-      [Unit]
-      Description=etcd3-restart
-
-      [Service]
-      Type=oneshot
-      ExecStartPre=/usr/bin/systemctl stop etcd3.service
-      ExecStartPre=/usr/bin/bash -c 'while systemctl is-active --quiet etcd3.service; do sleep 1 && echo waiting for etcd3 to stop; done'
-      ExecStart=/usr/bin/systemctl start etcd3.service
-
-      [Install]
-      WantedBy=multi-user.target
-  - name: etcd3-restart.timer
-    enable: true
-    command: start
-    content: |
-      [Unit]
-      Description=Timer
-
-      [Timer]
-      OnCalendar=13:00
-      Unit=etcd3-restart.service
-
-      [Install]
-      WantedBy=multi-user.target
   - name: k8s-proxy.service
     enable: true
     command: start

--- a/templates.go
+++ b/templates.go
@@ -559,7 +559,7 @@ coreos:
     command: start
     content: |
       [Unit]
-      Description=Set ownership to etcd2 data dir
+      Description=Set ownership to etcd3 data dir
       Wants=network-online.target
 
       [Service]
@@ -600,62 +600,77 @@ coreos:
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: etcd2.service
+    command: stop
+    enable: false
+    mask: true
+  - name: etcd3.service
     enable: true
     command: start
     content: |
       [Unit]
-      Description=etcd2
+      Description=etcd3
       Requires=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
-      Conflicts=etcd.service
+      Conflicts=etcd.service etcd2.service
       Wants=calico-node.service
       StartLimitIntervalSec=0
 
       [Service]
-      User=etcd
-      Type=notify
       Restart=always
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
+      Environment=IMAGE=quay.io/coreos/etcd:v3.1.7
+      Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
+      ExecStartPre=-/usr/bin/docker stop  $NAME
+      ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-crt.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
-      ExecStart=/usr/bin/etcd2 --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:2379 \
-                               --data-dir=/etc/kubernetes/data/etcd/ \
-                               --initial-advertise-peer-urls=https://127.0.0.1:2380 \
-                               --listen-client-urls=https://0.0.0.0:2379 \
-                               --listen-peer-urls=https://${DEFAULT_IPV4}:2380 \
-                               --initial-cluster-token k8s-etcd-cluster \
-                               --initial-cluster etcd0=https://127.0.0.1:2380 \
-                               --initial-cluster-state new \
-                               --ca-file=/etc/kubernetes/ssl/etcd/server-ca.pem \
-                               --cert-file=/etc/kubernetes/ssl/etcd/server-crt.pem \
-                               --key-file=/etc/kubernetes/ssl/etcd/server-key.pem \
-                               --peer-ca-file=/etc/kubernetes/ssl/etcd/server-ca.pem \
-                               --peer-cert-file=/etc/kubernetes/ssl/etcd/server-crt.pem \
-                               --peer-key-file=/etc/kubernetes/ssl/etcd/server-key.pem \
-                               --peer-client-cert-auth=true \
-                               --name etcd0
+      ExecStart=/usr/bin/docker run \
+          -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
+          -v /etc/kubernetes/ssl/etcd/:/etc/etcd \
+          -v /etc/kubernetes/data/etcd/:/var/lib/etcd  \
+          --net=host  \
+          --name $NAME \
+          $IMAGE \
+          etcd \
+          --name etcd0 \
+          --trusted-ca-file /etc/etcd/server-ca.pem \
+          --cert-file /etc/etcd/server-crt.pem \
+          --key-file /etc/etcd/server-key.pem\
+          --peer-trusted-ca-file /etc/etcd/server-ca.pem \
+          --peer-cert-file /etc/etcd/server-crt.pem \
+          --peer-key-file /etc/etcd/server-key.pem \
+          --peer-client-cert-auth=true \
+          --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:2379 \
+          --initial-advertise-peer-urls=https://127.0.0.1:2380 \
+          --listen-client-urls=https://0.0.0.0:2379 \
+          --listen-peer-urls=https://${DEFAULT_IPV4}:2380 \
+          --initial-cluster-token k8s-etcd-cluster \
+          --initial-cluster etcd0=https://127.0.0.1:2380 \
+          --initial-cluster-state new \
+          --data-dir=/var/lib/etcd
 
       [Install]
       WantedBy=multi-user.target
-  - name: etcd2-restart.service
+  - name: etcd3-restart.service
     enable: true
     content: |
       [Unit]
-      Description=etcd2-restart
+      Description=etcd3-restart
 
       [Service]
       Type=oneshot
-      ExecStartPre=/usr/bin/systemctl stop etcd2.service
-      ExecStartPre=/usr/bin/bash -c 'while systemctl is-active --quiet etcd2.service; do sleep 1 && echo waiting for etcd2 to stop; done'
-      ExecStart=/usr/bin/systemctl start etcd2.service
+      ExecStartPre=/usr/bin/systemctl stop etcd3.service
+      ExecStartPre=/usr/bin/bash -c 'while systemctl is-active --quiet etcd3.service; do sleep 1 && echo waiting for etcd3 to stop; done'
+      ExecStart=/usr/bin/systemctl start etcd3.service
 
       [Install]
       WantedBy=multi-user.target
-  - name: etcd2-restart.timer
+  - name: etcd3-restart.timer
     enable: true
     command: start
     content: |
@@ -664,7 +679,7 @@ coreos:
 
       [Timer]
       OnCalendar=13:00
-      Unit=etcd2-restart.service
+      Unit=etcd3-restart.service
 
       [Install]
       WantedBy=multi-user.target

--- a/templates.go
+++ b/templates.go
@@ -620,7 +620,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE=quay.io/coreos/etcd:v3.1.7
+      Environment=IMAGE=quay.io/coreos/etcd:v3.1.8
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME


### PR DESCRIPTION
Upgrading etcd to etcdv3 and moving etcd to container.
Its working, but it cannot be fully tested because current calico does not support etcdv3 (etcdv3 forces TLS 1.2 and old calico is trying TLS 1.0 ), so we have to wait for https://github.com/giantswarm/k8scloudconfig/pull/123