### PR TITLE
fix wait for domains

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -363,7 +363,7 @@ write_files:
   permissions: 0544
   content: |
       #!/bin/bash
-      domains=( {{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} )
+      domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
 
       for domain in $domains; do
         until nslookup $domain; do
@@ -1274,7 +1274,7 @@ write_files:
   permissions: 0544
   content: |
       #!/bin/bash
-      domains=( {{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} )
+      domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
 
       for domain in $domains; do
         until nslookup $domain; do


### PR DESCRIPTION
Current script only check for etcd domain  and ignores API domain

```
core@ip-10-0-130-47 /etc/systemd/system $ bash /opt/wait-for-domains 
Server:		10.0.0.2
Address:	10.0.0.2#53

Non-authoritative answer:
Name:	etcd.9vkwk.g8s.eu-west-1.adidas.aws.giantswarm.io
Address: 35.157.247.232
Name:	etcd.9vkwk.g8s.eu-west-1.adidas.aws.giantswarm.io
Address: 52.28.36.2

Successfully resolved domain etcd.9vkwk.g8s.eu-west-1.adidas.aws.giantswarm.io
core@ip-10-0-130-47 /etc/systemd/system $ vim /opt/wait-for-domains
```