### PR TITLE
fix k8s addons calico wait

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -694,7 +694,7 @@ write_files:
       # wait for healthy calico - we check for pods - desired vs ready
       while
           # result of this is 'eval [ "$DESIRED_POD_COUNT" -eq "$READY_POD_COUNT" ]'
-          eval $(/opt/bin/kubectl --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$3"\" ] "}')
+          eval $(/opt/bin/kubectl --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
           [ "$?" -ne "0" ]
       do
           echo "Waiting for calico to be ready . . "


### PR DESCRIPTION
previous version was checking desired versus current instead of desired versus ready

