### PR TITLE
fix nginx cm namespace

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -612,6 +612,7 @@ write_files:
     apiVersion: v1
     metadata:
       name: ingress-nginx
+      namespace: kube-system
       labels:
         k8s-addon: ingress-nginx.addons.k8s.io
     data:


### PR DESCRIPTION
There was a namespace missing so it was deploying it to `default`

We didn't realize before, cause with api calls we were calling the namespace anyway. with kubectl we are not and we did not check IC after the move.