### PR TITLE
changed port for etcd domain from 2379 to 443

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -43,7 +43,7 @@ write_files:
       namespace: kube-system
     data:
       # Configure this with the location of your etcd cluster.
-      etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:2379"
+      etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:443"
 
       # Configure the Calico backend to use.
       calico_backend: "bird"
@@ -1013,7 +1013,7 @@ coreos:
           --peer-cert-file /etc/etcd/server-crt.pem \
           --peer-key-file /etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
-          --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:2379 \
+          --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:443 \
           --initial-advertise-peer-urls=https://127.0.0.1:2380 \
           --listen-client-urls=https://0.0.0.0:2379 \
           --listen-peer-urls=https://${DEFAULT_IPV4}:2380 \
@@ -1167,7 +1167,7 @@ coreos:
       --etcd-prefix={{.Cluster.Etcd.Prefix}} \
       --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota \
       --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}} \
-      --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:2379 \
+      --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:443 \
       --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem \
       --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem \
       --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1197. There was a Slack conversation around this issue. See https://gigantic.slack.com/archives/C2MS2VB37/p1496756711183060. 

The idea is to align the ports under which etcd is accessible via domain. KVM and AWS should use `etcd.domain:443`. At the moment AWS uses `etcd.domain:2379`, which does not work in KVM, because the Kemps are configured to listen on `443`. The easiest way to align this is to change it for AWS where ELB configuration has to be modified. 