### PR TITLE
add VerbatimSection to cloud config

### DIFF
--- a/fake_operator.go
+++ b/fake_operator.go
@@ -9,3 +9,7 @@ func (f *FakeExtension) Files() ([]FileAsset, error) {
 func (f *FakeExtension) Units() ([]UnitAsset, error) {
 	return nil, nil
 }
+
+func (f *FakeExtension) VerbatimSections() []VerbatimSection {
+	return nil
+}

--- a/operator.go
+++ b/operator.go
@@ -35,9 +35,17 @@ type UnitAsset struct {
 	Content  []string
 }
 
+// VerbatimSection is a blob of YAML we want to add to the
+// CloudConfig, with no variable interpolation.
+type VerbatimSection struct {
+	Name    string
+	Content string
+}
+
 type Extension interface {
 	Files() ([]FileAsset, error)
 	Units() ([]UnitAsset, error)
+	VerbatimSections() []VerbatimSection
 }
 
 func RenderAssetContent(assetContent string, params interface{}) ([]string, error) {

--- a/templates.go
+++ b/templates.go
@@ -1286,6 +1286,10 @@ coreos:
       WantedBy=multi-user.target
   update:
     reboot-strategy: off
+
+{{ range .Extension.VerbatimSections }}
+{{ .Content }}
+{{ end }}
 `
 
 	WorkerTemplate = `#cloud-config
@@ -1575,6 +1579,10 @@ coreos:
       WantedBy=multi-user.target
   update:
     reboot-strategy: off
+
+{{ range .Extension.VerbatimSections }}
+{{ .Content }}
+{{ end }}
 `
 
 	testTemplate = `foo: {{.Foo}}`


### PR DESCRIPTION
VerbatimSection represents a generic, top-level piece of YAML that should be
included verbatim in the CloudConfig. i.e. it's neither a `Unit` block, or a `File` block.

Example:

```
storage:
  filesystems:
    - name: ephemeral1
      mount:
        device: /dev/xvdb
        format: ext3
        create:
          force: true`
```

The AWS operator needs this for Instance Storage, whereas KVM doesn't. Therefore, we need to be able to inject it in the CloudConfig.

Towards https://github.com/giantswarm/giantswarm/issues/1530.