### PR TITLE
Turn etcd auth on

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1013,6 +1013,7 @@ coreos:
           --trusted-ca-file /etc/etcd/server-ca.pem \
           --cert-file /etc/etcd/server-crt.pem \
           --key-file /etc/etcd/server-key.pem\
+          --client-cert-auth=true \
           --peer-trusted-ca-file /etc/etcd/server-ca.pem \
           --peer-cert-file /etc/etcd/server-crt.pem \
           --peer-key-file /etc/etcd/server-key.pem \


### PR DESCRIPTION
we have only two services (k8s api and calico)
that use etcd and both of them have certificates
and keys for access.

Fixes https://github.com/giantswarm/giantswarm/issues/1550