### PR TITLE
Mount /var/lib/kubelet as shared

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1092,7 +1092,7 @@ coreos:
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
       -v /var/lib/docker/:/var/lib/docker:rw \
-      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,shared \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
       -v /etc/cni/net.d/:/etc/cni/net.d/ \


### PR DESCRIPTION
This fixes issue with pod termination.
Problem is that duplicate volume mounts appear
inside kubelet container. But kubelet
unmounts only one inside /var/lib/kubelet.
Other one looks like this

`/var/lib/docker/overlay/LAYERID/merged/var/lib/kubelet/pods/PODID/.../default-token-8t5b0`

So kubelet ends up with Device or resource busy, when
tries to do smth with parent directory.

I can reproduce problem on local Docker.

My assumption that /var/lib/docker got mounted as shared (not as private),
so when kubelet mounts volume it becoms visible in docker overlay
and propagated inside kubelet second time.

Not sure why it doesn't work other way around for unmount.

BTW such behaviour can be fixed both by making

1) /var/lib/kubelet:rw,shared shared like here
2) /var/lib/docker:rw,private

Good article about mounts https://lwn.net/Articles/689856/

These guys are also use shared mount here https://github.com/kubernetes/kubernetes-anywhere/blob/master/phase2/ignition/vanilla/kubelet.service#L19