### PR TITLE
increase-conntrack-limit

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1114,6 +1114,7 @@ coreos:
       --proxy-mode=iptables \
       --logtostderr=true \
       --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
+      --conntrack-max-per-core 131072 \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
@@ -1595,6 +1596,7 @@ coreos:
       --proxy-mode=iptables \
       --logtostderr=true \
       --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
+      --conntrack-max-per-core 131072 \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
towards https://github.com/giantswarm/adidas/issues/134

in future, we may wanna have this configurable, but for now, it's better if we don't have to configure it manually

ip conntrack is for tracking connection for iptables
if this limit is reached iptables is not able to track more connection so the rest is dropped

the implication is just small increase of RAM usage
