### PR TITLE
update-etcd

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1046,7 +1046,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE=quay.io/coreos/etcd:v3.1.8
+      Environment=IMAGE=quay.io/coreos/etcd:v3.2.7
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
@@ -1079,7 +1079,9 @@ coreos:
           --initial-cluster-token k8s-etcd-cluster \
           --initial-cluster etcd0=https://127.0.0.1:2380 \
           --initial-cluster-state new \
-          --data-dir=/var/lib/etcd
+          --data-dir=/var/lib/etcd \
+          --auto-compaction-retention=1 \
+          --enable-v2
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
* update etcd version
* set `--enable-v2` for backward API 2 compatibility
* enable `auto-compaction`

towards https://github.com/giantswarm/giantswarm/issues/1841