### PR TITLE
Make master unschedulable with taint

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -107,10 +107,14 @@ write_files:
             k8s-app: calico-node
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
-            scheduler.alpha.kubernetes.io/tolerations: |
-              [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-               {"key":"CriticalAddonsOnly", "operator":"Exists"}]
         spec:
+          # Tolerations part was taken from calico manifest for kubeadm as we are using same taint for master.
+          tolerations:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+            effect: NoSchedule
+          - key: CriticalAddonsOnly
+            operator: Exists
           hostNetwork: true
           serviceAccountName: calico-node
           containers:
@@ -1195,10 +1199,10 @@ coreos:
       --cluster-domain={{.Cluster.Kubernetes.Domain}} \
       --network-plugin=cni \
       --register-node=true \
-      --register-schedulable=false \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
       --allow-privileged=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
-      --node-labels="role=master,kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="node-role.kubernetes.io/master,role=master,kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
use correct label and taint for master (leave existing label for compatibility)
See source: https://github.com/kubernetes/kubernetes/pull/41835

use proper tolerations for Calico from kubeadm.
Default Calico manifests contain outdated toleraiotns
See source: https://github.com/projectcalico/calico/blob/master/v2.5/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml#L71-L77

Discussed in detail here: https://github.com/giantswarm/aws-terraform/pull/91