### PR TITLE
Disable default bridge

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1019,9 +1019,9 @@ coreos:
     - name: 10-giantswarm-extra-args.conf
       content: |
         [Service]
-        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --disable-legacy-registry=true {{.Cluster.Docker.Daemon.ExtraArgs}}"
+        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs {{.Cluster.Docker.Daemon.ExtraArgs}}"
         Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
-        Environment="DOCKER_OPTS=--live-restore"
+        Environment="DOCKER_OPTS=--live-restore --icc=false --disable-legacy-registry=true"
   - name: k8s-setup-network-env.service
     enable: true
     command: start

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -197,9 +197,9 @@ coreos:
     - name: 10-giantswarm-extra-args.conf
       content: |
         [Service]
-        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --disable-legacy-registry=true {{.Cluster.Docker.Daemon.ExtraArgs}}"
+        Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs {{.Cluster.Docker.Daemon.ExtraArgs}}"
         Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
-        Environment="DOCKER_OPTS=--live-restore"
+        Environment="DOCKER_OPTS=--live-restore --icc=false --disable-legacy-registry=true"
 
   - name: k8s-setup-network-env.service
     enable: true


### PR DESCRIPTION
2.1 - Ensure network traffic is restricted between containers on the default bridge

This will disable default `bridge` network on docker daemon.

icc=false should be ok as we are not using docker bridged network.

For me it set drop on following rule, not whole system.

-A FORWARD -i docker0 -o docker0 -j DROP