### PR TITLE
Disable userland

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1021,7 +1021,7 @@ coreos:
         [Service]
         Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --disable-legacy-registry=true {{.Cluster.Docker.Daemon.ExtraArgs}}"
         Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
-        Environment="DOCKER_OPTS=--live-restore"
+        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false"
   - name: k8s-setup-network-env.service
     enable: true
     command: start

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -199,7 +199,7 @@ coreos:
         [Service]
         Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --disable-legacy-registry=true {{.Cluster.Docker.Daemon.ExtraArgs}}"
         Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
-        Environment="DOCKER_OPTS=--live-restore"
+        Environment="DOCKER_OPTS=--live-restore --userland-proxy=false"
 
   - name: k8s-setup-network-env.service
     enable: true


### PR DESCRIPTION
Disable Userland proxy for Docker

cc @puja108 LGTM, userland proxy was supposed to be disabled by default since Docker 1.7 (it was only needed for old RHEL versions or sth), but still open issue :D