### PR TITLE
Use hostnames instead of IP addresses

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1185,7 +1185,6 @@ coreos:
       /hyperkube kubelet \
       --address=${DEFAULT_IPV4} \
       --port={{.Cluster.Kubernetes.Kubelet.Port}} \
-      --hostname-override=${DEFAULT_IPV4} \
       --node-ip=${DEFAULT_IPV4} \
       --api-servers=https://{{.Cluster.Kubernetes.API.Domain}} \
       --containerized \

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -304,7 +304,6 @@ coreos:
       /hyperkube kubelet \
       --address=${DEFAULT_IPV4} \
       --port={{.Cluster.Kubernetes.Kubelet.Port}} \
-      --hostname-override=${DEFAULT_IPV4} \
       --node-ip=${DEFAULT_IPV4} \
       --api-servers=https://{{.Cluster.Kubernetes.API.Domain}} \
       --containerized \


### PR DESCRIPTION
In AWS nodes already have hostnames and not IPs.
Looks like --cloud-provider=aws takes precedence
over --hostname-overwrite.

So this change DOES NOT change actual behaviour.

We want to use calico-node-controller
that syncronizes nodes from k8s with Calico.
By default k8s and Calico use hostnames,
but we used IP addresses. This change
switches back to hostnames.

Part of https://github.com/giantswarm/k8scloudconfig/issues/162