### PR TITLE
k8s CIS benchmark: audit

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1281,7 +1281,8 @@ coreos:
       --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
       --audit-log-path=/var/log/apiserver/audit.log \
       --audit-log-maxage=30 \
-      --audit-log-maxbackup=10
+      --audit-log-maxbackup=10 \
+	  --audit-log-maxsize=100
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager.service

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1279,7 +1279,8 @@ coreos:
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
       --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
-	  --audit-log-path=/var/log/apiserver/audit.log
+      --audit-log-path=/var/log/apiserver/audit.log \
+      --audit-log-maxage=30
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager.service

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1280,7 +1280,8 @@ coreos:
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
       --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
       --audit-log-path=/var/log/apiserver/audit.log \
-      --audit-log-maxage=30
+      --audit-log-maxage=30 \
+      --audit-log-maxbackup=10
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager.service

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1278,7 +1278,8 @@ coreos:
       --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
-      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
+      --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
+	  --audit-log-path=/var/log/apiserver/audit.log
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager.service

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1282,7 +1282,7 @@ coreos:
       --audit-log-path=/var/log/apiserver/audit.log \
       --audit-log-maxage=30 \
       --audit-log-maxbackup=10 \
-	  --audit-log-maxsize=100
+      --audit-log-maxsize=100
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
   - name: k8s-controller-manager.service


### PR DESCRIPTION
Enable audit for `api-server` as required by Kubernetes CIS benchmark

- [x] 1.1.16 Ensure that the --audit-log-path argument is set as appropriate (Scored)
- [x] 1.1.17 Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)
- [x] 1.1.18 Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)
- [x] 1.1.19 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)