### PR TITLE
Rolling update of Calico nodes

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -101,6 +101,10 @@ write_files:
       selector:
         matchLabels:
           k8s-app: calico-node
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
       template:
         metadata:
           labels:


### PR DESCRIPTION
By default user needs manually delete pods
after new DaemonSet version applied.

related changes:
https://github.com/giantswarm/aws-terraform/pull/118
https://github.com/giantswarm/hive/pull/146