### PR TITLE
k8s-use-internalIP-for-kubelet

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1306,6 +1306,7 @@ coreos:
       --insecure_bind_address=0.0.0.0 \
       --insecure_port={{.Cluster.Kubernetes.API.InsecurePort}} \
       --kubelet_https=true \
+      --kubelet-preferred-address-types=InternalIP \
       --secure_port={{.Cluster.Kubernetes.API.SecurePort}} \
       --bind-address=${DEFAULT_IPV4} \
       --etcd-prefix={{.Cluster.Etcd.Prefix}} \


### PR DESCRIPTION
fix for https://github.com/giantswarm/k8scloudconfig/pull/207
by default api is accessing machines via hostnames which are not existing in case of kvm