### PR TITLE
add AlwaysPullImages in api-server admission control

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1850,7 +1850,7 @@ coreos:
       --repair-malformed-updates=false \
       --service-account-lookup=true \
       --authorization-mode=RBAC \
-      --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy \
+      --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy,AlwaysPullImages \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}} \
       --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:443 \


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

Setting admission control policy to AlwaysPullImages forces every new pod to pull the
required images every time. In a multitenant cluster users can be assured that their private
images can only be used by those who have the credentials to pull them. Without this
admisssion control policy, once an image has been pulled to a node, any pod from any user
can use it simply by knowing the image’s name, without any authorization check against
the image ownership. When this plug-in is enabled, images are always pulled prior to
starting containers, which means valid credentials are required.

Related to : https://github.com/giantswarm/giantswarm/issues/2028 rule: 1.1.12 Ensure that the admission control policy is set to AlwaysPullImages (Scored) Follow-up: No Impact