### PR TITLE
Disable anonymous access and insecure port

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1553,28 +1553,28 @@ write_files:
           done
       done
       echo "Addons successfully installed"
-  - path: /etc/kubernetes/config/addons-kubeconfig.yml
-    owner: root
-    permissions: 0644
-    content: |
-      apiVersion: v1
-      kind: Config
-      users:
-      - name: proxy
-        user:
-          client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
-          client-key: /etc/kubernetes/ssl/apiserver-key.pem
-      clusters:
-      - name: local
-        cluster:
-          certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
-          server: https://{{.Cluster.Kubernetes.API.Domain}}
-      contexts:
-      - context:
-          cluster: local
-          user: proxy
-        name: service-account-context
-      current-context: service-account-context
+- path: /etc/kubernetes/config/addons-kubeconfig.yml
+  owner: root
+  permissions: 0644
+  content: |
+    apiVersion: v1
+    kind: Config
+    users:
+    - name: proxy
+      user:
+        client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+        client-key: /etc/kubernetes/ssl/apiserver-key.pem
+    clusters:
+    - name: local
+      cluster:
+        certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
+    contexts:
+    - context:
+        cluster: local
+        user: proxy
+      name: service-account-context
+    current-context: service-account-context
 
 - path: /etc/kubernetes/config/proxy-kubeconfig.yml
   owner: root

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1276,6 +1276,8 @@ write_files:
   permissions: 0544
   content: |
       #!/bin/bash
+
+      export KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml
       # kubectl 1.8.1
       KUBECTL=quay.io/giantswarm/docker-kubectl:1dc536ec6dc4597ba46769b3d5d6ce53a7e62038
 
@@ -1358,6 +1360,29 @@ write_files:
           done
       done
       echo "Addons successfully installed"
+  - path: /etc/kubernetes/config/addons-kubeconfig.yml
+    owner: root
+    permissions: 0644
+    content: |
+      apiVersion: v1
+      kind: Config
+      users:
+      - name: proxy
+        user:
+          client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+          client-key: /etc/kubernetes/ssl/apiserver-key.pem
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+          server: https://{{.Cluster.Kubernetes.API.Domain}}
+      contexts:
+      - context:
+          cluster: local
+          user: proxy
+        name: service-account-context
+      current-context: service-account-context
+
 - path: /etc/kubernetes/config/proxy-kubeconfig.yml
   owner: root
   permissions: 0644

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1865,7 +1865,8 @@ coreos:
       /hyperkube apiserver \
       --allow_privileged=true \
       --insecure_bind_address=0.0.0.0 \
-      --insecure_port={{.Cluster.Kubernetes.API.InsecurePort}} \
+      --anonymous-auth=false \
+      --insecure_port=0 \
       --kubelet_https=true \
       --kubelet-preferred-address-types=InternalIP \
       --secure_port={{.Cluster.Kubernetes.API.SecurePort}} \

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1464,8 +1464,12 @@ write_files:
 
       /usr/bin/docker pull $KUBECTL
 
+##
+-e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes 
+##
+
       # wait for healthy master
-      while [ "$(/usr/bin/docker run --net=host --rm $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
+      while [ "$(/usr/bin/docker run --e KUBECONFIG=${KUBECONFIG} -net=host --rm /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
 
       # apply Security bootstrap (RBAC and PSP)
       SECURITY_FILES="rbac_bindings.yaml rbac_roles.yaml psp_policies.yaml psp_roles.yaml psp_binding.yaml"
@@ -1473,7 +1477,7 @@ write_files:
       for manifest in $SECURITY_FILES
       do
           while
-              /usr/bin/docker run --net=host --rm -v /srv:/srv $KUBECTL apply -f /srv/$manifest
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /src/$manifest, retrying in 5 sec"
@@ -1495,7 +1499,7 @@ write_files:
       for manifest in $CALICO_FILES
       do
           while
-              /usr/bin/docker run --net=host --rm -v /srv:/srv $KUBECTL apply -f /srv/$manifest
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /src/$manifest, retrying in 5 sec"
@@ -1506,9 +1510,9 @@ write_files:
       # wait for healthy calico - we check for pods - desired vs ready
       while
           # result of this is 'eval [ "$DESIRED_POD_COUNT" -eq "$READY_POD_COUNT" ]'
-          /usr/bin/docker run --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system  get ds calico-node 2>/dev/null >/dev/null
+          /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system  get ds calico-node 2>/dev/null >/dev/null
           RET_CODE_1=$?
-          eval $(/usr/bin/docker run --net=host --rm $KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
+          eval $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
           RET_CODE_2=$?
           [ "$RET_CODE_1" -ne "0" ] || [ "$RET_CODE_2" -ne "0" ]
       do
@@ -1519,7 +1523,7 @@ write_files:
       # apply default storage class
       if [ -f /srv/default-storage-class.yaml ]; then
           while
-              /usr/bin/docker run --net=host --rm -v /srv:/srv $KUBECTL apply -f /srv/default-storage-class.yaml
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/default-storage-class.yaml
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /srv/default-storage-class.yaml, retrying in 5 sec"
@@ -1545,7 +1549,7 @@ write_files:
       for manifest in $MANIFESTS
       do
           while
-              /usr/bin/docker run --net=host --rm -v /srv:/srv $KUBECTL apply -f /srv/$manifest
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /srv/$manifest, retrying in 5 sec"

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1464,12 +1464,8 @@ write_files:
 
       /usr/bin/docker pull $KUBECTL
 
-##
--e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes 
-##
-
       # wait for healthy master
-      while [ "$(/usr/bin/docker run --e KUBECONFIG=${KUBECONFIG} -net=host --rm /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
+      while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
 
       # apply Security bootstrap (RBAC and PSP)
       SECURITY_FILES="rbac_bindings.yaml rbac_roles.yaml psp_policies.yaml psp_roles.yaml psp_binding.yaml"
@@ -1477,7 +1473,7 @@ write_files:
       for manifest in $SECURITY_FILES
       do
           while
-              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /src/$manifest, retrying in 5 sec"
@@ -1499,7 +1495,7 @@ write_files:
       for manifest in $CALICO_FILES
       do
           while
-              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /src/$manifest, retrying in 5 sec"
@@ -1512,7 +1508,7 @@ write_files:
           # result of this is 'eval [ "$DESIRED_POD_COUNT" -eq "$READY_POD_COUNT" ]'
           /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system  get ds calico-node 2>/dev/null >/dev/null
           RET_CODE_1=$?
-          eval $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
+          eval $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
           RET_CODE_2=$?
           [ "$RET_CODE_1" -ne "0" ] || [ "$RET_CODE_2" -ne "0" ]
       do
@@ -1523,7 +1519,7 @@ write_files:
       # apply default storage class
       if [ -f /srv/default-storage-class.yaml ]; then
           while
-              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/default-storage-class.yaml
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/default-storage-class.yaml
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /srv/default-storage-class.yaml, retrying in 5 sec"
@@ -1535,7 +1531,7 @@ write_files:
 
       # apply k8s addons
       MANIFESTS="kube-proxy-sa.yaml\
-                 kube-proxy-ds.yaml\
+     kube-proxy-ds.yaml\
                  kubedns-cm.yaml\
                  kubedns-sa.yaml\
                  kubedns-dep.yaml\
@@ -1549,7 +1545,7 @@ write_files:
       for manifest in $MANIFESTS
       do
           while
-              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /srv/$manifest, retrying in 5 sec"


### PR DESCRIPTION
Regarding k8s CIS benchmark, we need to disable anonymous access to the api and use 0 as insecure port.

Currently, k8s-addons use kubectl with anonymous access. We have to provide a kubeconfig for this. eg. proxy-kubeconfig

in k8scc the insecure port is set by `--insecure_port={{.Cluster.Kubernetes.API.InsecurePort}}`

**question:** is it a problem for us to disable it? and do you prefer to remove insecure port from struct and use `0` directly in k8scc or having `0` as default value in the struct and let the operator overriding it

Rel: https://github.com/giantswarm/giantswarm/issues/2020