### PR TITLE
remove proxy protocol config

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -726,7 +726,6 @@ write_files:
     data:
       server-name-hash-bucket-size: "1024"
       server-name-hash-max-size: "1024"
-      use-proxy-protocol: "true"
 - path: /srv/ingress-controller-dep.yml
   owner: root
   permissions: 0644


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/1952

The first tests were not executed properly, the actual result is that ingress-nginx with proxy protocol doesn't work as expected on kvm:
```
$ curl http://10.0.4.112:30100/ -H "Host: helloworld.fvx9p.gigantic.io"
curl: (52) Empty reply from server
```
These changes revert the `use-proxy-protocol` setting for the ingress-nginx configmap.