### PR TITLE
etcd-defrag-wait-for-domains

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1737,8 +1737,8 @@ coreos:
     content: |
       [Unit]
       Description=etcd defragmentation job
-      After=docker.service etcd3.service
-      Requires=docker.service etcd3.service
+      After=docker.service etcd3.service wait-for-domains.service
+      Requires=docker.service etcd3.service wait-for-domains.service
 
       [Service]
       Type=oneshot


### PR DESCRIPTION
on aws the `etcd3-defragmentation` fails because at time of start the dns is not yet created