### PR TITLE
run-calico-controller-on-master

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -117,7 +117,18 @@ write_files:
           namespace: kube-system
           labels:
             k8s-app: calico-node-controller
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
+          tolerations:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+            effect: NoSchedule
+          - key: CriticalAddonsOnly
+            operator: Exists
+          nodeSelector:
+            role: master
+          hostNetwork: true
           serviceAccountName: calico-node-controller
           containers:
             - name: calico-node-controller

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -127,7 +127,7 @@ write_files:
           - key: CriticalAddonsOnly
             operator: Exists
           nodeSelector:
-            role: master
+            node-role.kubernetes.io/master: ""
           hostNetwork: true
           serviceAccountName: calico-node-controller
           containers:


### PR DESCRIPTION
this PR moves `calico-node-controller` to master and remove the need of working calico network in order to work.

I have encountered a scenario when there was deadlock - calico-node was not starting because of duplicate ip and calico-node-controller can't clean the config because networking was not working.

This PR solve this issue.