### PR TITLE
add SecurityContextDeny to AdmissionControl

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -2017,7 +2017,7 @@ coreos:
       --repair-malformed-updates=false \
       --service-account-lookup=true \
       --authorization-mode=RBAC \
-      --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy \
+      --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy,SecurityContextDeny \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}} \
       --etcd-servers=https://127.0.0.1:2379 \


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>
Regarding this: 1.1.14 Ensure that the admission control policy is set to SecurityContextDeny

As far as we already have RBAC and PSP, we can disable SecurityContext specific
