### PR TITLE
reserve-resources-for-critical-components

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -507,6 +507,10 @@ write_files:
                 # kubernetes.default to the correct service clusterIP.
                 - name: CONFIGURE_ETC_HOSTS
                   value: "true"
+              resources:
+                requests:
+                  cpu: 30m
+                  memory: 90Mi
               volumeMounts:
                 # Mount in the etcd TLS secrets.
                 - mountPath: /etc/kubernetes/ssl/etcd
@@ -875,6 +879,10 @@ write_files:
                 path: /healthz
                 port: 10254
                 scheme: HTTP
+            resources:
+              requests:
+                memory: "350Mi"
+                cpu: "500m"
             livenessProbe:
               httpGet:
                 path: /healthz
@@ -983,6 +991,10 @@ write_files:
                   port: 10256
                 initialDelaySeconds: 10
                 periodSeconds: 3
+              resources:
+                requests:
+                  memory: "125Mi"
+                  cpu: "75m"
               securityContext:
                 privileged: true
               volumeMounts:
@@ -1986,6 +1998,8 @@ coreos:
       --allow-privileged=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
       --node-labels="node-role.kubernetes.io/master,role=master,kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --kube-reserved="cpu=150m,memory=250Mi" \
+      --system-reserved="cpu=150m,memory=250Mi" \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME

--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -993,7 +993,7 @@ write_files:
                 periodSeconds: 3
               resources:
                 requests:
-                  memory: "125Mi"
+                  memory: "80Mi"
                   cpu: "75m"
               securityContext:
                 privileged: true

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -290,6 +290,8 @@ coreos:
       --allow-privileged=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
       --node-labels="kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --kube-reserved="cpu=150m,memory=250Mi" \
+      --system-reserved="cpu=150m,memory=250Mi" \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/2112

set reserved resource for:
* os system - 0.15CPU 250MiB ram
* kubelet - 0.15 CPU 250MiB ram
* kube-proxy - 0.075CPU 80MiB ram
* IC controller - 0.5CPU 350MiB ram
* calico kube controllers - 0.03CPU 90MiB ram


components that already have reserved resources:
* calico node - 0.25 CPU
* kube-dns - 0.1CPU 70MiB ram + 0.15CPU 10MiB + 0.01CPU + 20MiB ram
* default-backend - 0.01CPU 20MiB ram

Lets have a discussion here about the limits. Daniel from adidas said that he set reservation for IC to 1CPU and 500 MiB ram, but that seems to be way to muuch if we consider how big default machines are.

Lets do some math:
CPU: on each node: 0.15+0.15+0.075+0.5+0.25 = 1.125CPU (m3.large has 2 CPUs)
RAM: on each node: 250+250+80+350 = 920 MiB (m3.large has 8GB of ram )
+  another 3x(0.1+0.15+0.01) +2xx0.01+0.03= 0.83 CPU spread accross  worker nodes
+ some small extra ram usage.

This seems to be hard to setup by one config. As for big workloads IC limits may need to be bigger but if we set it globally, our reservation will eat like 75% of CPU resources on cloud (if we use m3.large)

cc @r7vme @teemow @othylmann @corest @fgimenez 
