### PR TITLE
Fix indentation

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1552,7 +1552,7 @@ write_files:
 
       # apply k8s addons
       MANIFESTS="kube-proxy-sa.yaml\
-     kube-proxy-ds.yaml\
+                 kube-proxy-ds.yaml\
                  kubedns-cm.yaml\
                  kubedns-sa.yaml\
                  kubedns-dep.yaml\


### PR DESCRIPTION
Reverts this change https://github.com/giantswarm/k8scloudconfig/pull/224/files#diff-c0ae19d8351967dbe58eae812425f1a7L1532 and aims to prevent this error, which makes guest cluster creation fail:
```
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: 2017/11/14 15:10:29 Checking availability of "local-file"
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: 2017/11/14 15:10:29 Fetching user-data from datasource of type "local-file"
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: 2017/11/14 15:10:29 line 1539: error: did not find expected key
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: 2017/11/14 15:10:29 line 0: warning: incorrect type for "" (want struct)
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: 2017/11/14 15:10:29 Fetching meta-data from datasource of type "local-file"
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: 2017/11/14 15:10:29 Parsing user-data as cloud-config
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: Failed to parse user-data: YAML error: line 1539: did not find expected key
Nov 14 15:10:29 ip-10-1-12-78.eu-central-1.compute.internal bash[888]: Continuing...
```