### PR TITLE
backwards-compatibility-for-kube-proxy

### DIFF
--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -331,6 +331,7 @@ coreos:
   - name: k8s-proxy-watcher.service
     enable: true
     command: start
+    content: |
       [Unit]
       Description=k8s-proxy-watcher
       Wants=k8s-kubelet.service

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -331,7 +331,7 @@ coreos:
   - name: k8s-proxy-watcher.service
     enable: true
     command: start
-    [Unit]
+      [Unit]
       Description=k8s-proxy-watcher
       Wants=k8s-kubelet.service
       After=k8s-kubelet.service

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -295,6 +295,51 @@ coreos:
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
+  - name: k8s-proxy.service
+    enable: false
+    command: stop
+    content: |
+      [Unit]
+      Description=k8s-proxy
+      StartLimitIntervalSec=0
+
+      [Service]
+      Restart=always
+      RestartSec=0
+      TimeoutStopSec=10
+      EnvironmentFile=/etc/network-environment
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
+      Environment="NAME=%p.service"
+      Environment="NETWORK_CONFIG_CONTAINER="
+      ExecStartPre=/usr/bin/docker pull $IMAGE
+      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
+      ExecStartPre=-/usr/bin/docker rm -f $NAME      
+      ExecStart=/bin/sh -c "/usr/bin/docker run --rm --net=host --privileged=true \
+      --name $NAME \
+      -v /usr/share/ca-certificates:/etc/ssl/certs \
+      -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
+      -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
+      $IMAGE \
+      /hyperkube proxy \
+      --proxy-mode=iptables \
+      --logtostderr=true \
+      --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
+      --conntrack-max-per-core 131072 \
+      --v=2"
+      ExecStop=-/usr/bin/docker stop -t 10 $NAME
+      ExecStopPost=-/usr/bin/docker rm -f $NAME
+  - name: k8s-proxy-watcher.service
+    enable: true
+    command: start
+    [Unit]
+      Description=k8s-proxy-watcher
+      Wants=k8s-kubelet.service
+      After=k8s-kubelet.service
+      
+      [Service]
+      ExecStartPre=/bin/sh -c "sleep 2m"
+      ExecStart=/bin/sh -c "proxyCount=$(docker ps | grep 'kube-proxy' | wc -l);if [ "$proxyCount" == "0" ]; then sudo systemctl start k8s-proxy; fi;"
+
   - name: node-exporter.service
     enable: true
     command: start

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -337,8 +337,10 @@ coreos:
       After=k8s-kubelet.service
       
       [Service]
+      Type=oneshot
       ExecStartPre=/bin/sh -c "sleep 2m"
       ExecStart=/bin/sh -c "proxyCount=$(docker ps | grep 'kube-proxy' | wc -l);if [ "$proxyCount" == "0" ]; then sudo systemctl start k8s-proxy; fi;"
+      RemainAfterExit=yes
 
   - name: node-exporter.service
     enable: true


### PR DESCRIPTION
fix for https://github.com/giantswarm/giantswarm/issues/2122

There is situation where the new worker is spawned but master still doesn't run the new `kube-proxy` as daemon set that will cause that worker is without proxy.

This hack puts `k8s-proxy` unit back but its disabled by default. If after 2 mins after the kubelet start there are no `kube-proxy` pod running on the machine it will start the old k8s-proxy via systemd.