### PR TITLE
Remove kubeproxy unit

### DIFF
--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -295,54 +295,6 @@ coreos:
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
-  - name: k8s-proxy.service
-    enable: false
-    command: stop
-    content: |
-      [Unit]
-      Description=k8s-proxy
-      StartLimitIntervalSec=0
-
-      [Service]
-      Restart=always
-      RestartSec=0
-      TimeoutStopSec=10
-      EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
-      Environment="NAME=%p.service"
-      Environment="NETWORK_CONFIG_CONTAINER="
-      ExecStartPre=/usr/bin/docker pull $IMAGE
-      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
-      ExecStartPre=-/usr/bin/docker rm -f $NAME      
-      ExecStart=/bin/sh -c "/usr/bin/docker run --rm --net=host --privileged=true \
-      --name $NAME \
-      -v /usr/share/ca-certificates:/etc/ssl/certs \
-      -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
-      -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
-      $IMAGE \
-      /hyperkube proxy \
-      --proxy-mode=iptables \
-      --logtostderr=true \
-      --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
-      --conntrack-max-per-core 131072 \
-      --v=2"
-      ExecStop=-/usr/bin/docker stop -t 10 $NAME
-      ExecStopPost=-/usr/bin/docker rm -f $NAME
-  - name: k8s-proxy-watcher.service
-    enable: true
-    command: start
-    content: |
-      [Unit]
-      Description=k8s-proxy-watcher
-      Wants=k8s-kubelet.service
-      After=k8s-kubelet.service
-      
-      [Service]
-      Type=oneshot
-      ExecStartPre=/bin/sh -c "sleep 2m"
-      ExecStart=/bin/sh -c "proxyCount=$(docker ps | grep 'kube-proxy' | wc -l);if [ "$proxyCount" == "0" ]; then sudo systemctl start k8s-proxy; fi;"
-      RemainAfterExit=yes
-
   update:
     reboot-strategy: off
 

--- a/v_0_1_0/worker_template.go
+++ b/v_0_1_0/worker_template.go
@@ -295,6 +295,7 @@ coreos:
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME
+
   update:
     reboot-strategy: off
 


### PR DESCRIPTION
Removes kubeproxy unit and watcher added in #243 as it causes problems on AWS.

Clusters on AWS take longer to start due to nodes booting and ELBs. The timer means a second kube-proxy is created but the ingress ports are already bound so they fail.

Is this change needed for AWS? If not I'll add the units to kvm-operator so they can be embedded in the cloud config.



