### PR TITLE
fix master template

### DIFF
--- a/v_0_1_0/master_template.go
+++ b/v_0_1_0/master_template.go
@@ -1795,8 +1795,7 @@ coreos:
       Type=oneshot
       RemainAfterExit=yes
       TimeoutStartSec=0
-      ExecStart=/usr/bin/mkdir -p /etc/kubernetes/data/etcd
-      ExecStart=/usr/bin/chown etcd:etcd /etc/kubernetes/data/etcd
+      ExecStartPre=/bin/bash -c "/usr/bin/mkdir -p /etc/kubernetes/data/etcd; /usr/bin/chown etcd:etcd /etc/kubernetes/data/etcd"
       ExecStart=/usr/bin/chmod -R 700 /etc/kubernetes/data/etcd
   - name: docker.service
     enable: true


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

Due to multiple `ExecStart` instruction, the service was failing because the `chmod` was done before the `mkdir`

this PR fix the problem