### PR TITLE
v_3_0_0: allow setting custom K8s API address for master nodes

### DIFF
--- a/v_3_0_0/cloudconfig.go
+++ b/v_3_0_0/cloudconfig.go
@@ -36,6 +36,14 @@ func NewCloudConfig(config CloudConfigConfig) (*CloudConfig, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Template must not be empty")
 	}
 
+	// Set default params.
+	if config.Params.MasterAPIDomain == "" {
+		config.Params.MasterAPIDomain = config.Params.Cluster.Kubernetes.API.Domain
+	}
+	if config.Params.Apiserver.BindAddress == "" {
+		config.Params.Apiserver.BindAddress = defaultHyperkubeApiserverBindAddress
+	}
+
 	c := &CloudConfig{
 		config:   "",
 		params:   config.Params,

--- a/v_3_0_0/master_template.go
+++ b/v_3_0_0/master_template.go
@@ -1590,7 +1590,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
-        server: https://{{.Cluster.Kubernetes.API.Domain}}
+        server: https://{{.MasterAPIDomain}}
     contexts:
     - context:
         cluster: local
@@ -1613,7 +1613,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
-        server: https://{{.Cluster.Kubernetes.API.Domain}}
+        server: https://{{.MasterAPIDomain}}
     contexts:
     - context:
         cluster: local
@@ -1635,7 +1635,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
-        server: https://{{.Cluster.Kubernetes.API.Domain}}
+        server: https://{{.MasterAPIDomain}}
     contexts:
     - context:
         cluster: local
@@ -1657,7 +1657,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
-        server: https://{{.Cluster.Kubernetes.API.Domain}}
+        server: https://{{.MasterAPIDomain}}
     contexts:
     - context:
         cluster: local
@@ -1679,7 +1679,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
-        server: https://{{.Cluster.Kubernetes.API.Domain}}
+        server: https://{{.MasterAPIDomain}}
     contexts:
     - context:
         cluster: local
@@ -1995,7 +1995,7 @@ coreos:
       --machine-id-file=/rootfs/etc/machine-id \
       --cadvisor-port=4194 \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
-      --healthz-bind-address=${DEFAULT_IPV4} \
+      --healthz-bind-address={{.Hyperkube.Apiserver.BindAddress}} \
       --healthz-port=10248 \
       --cluster-dns={{.Cluster.Kubernetes.DNS.IP}} \
       --cluster-domain={{.Cluster.Kubernetes.Domain}} \
@@ -2072,7 +2072,7 @@ coreos:
       --kubelet_https=true \
       --kubelet-preferred-address-types=InternalIP \
       --secure_port={{.Cluster.Kubernetes.API.SecurePort}} \
-      --bind-address=${DEFAULT_IPV4} \
+      --bind-address={{.Hyperkube.Apiserver.BindAddress}} \
       --etcd-prefix={{.Cluster.Etcd.Prefix}} \
       --profiling=false \
       --repair-malformed-updates=false \

--- a/v_3_0_0/types.go
+++ b/v_3_0_0/types.go
@@ -2,8 +2,21 @@ package v_3_0_0
 
 import "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 
+const (
+	defaultHyperkubeApiserverBindAddress = "${DEFAULT_IPV4}"
+)
+
 type Params struct {
-	Cluster v1alpha1.Cluster
+	// MasterAPIDomain is a value of domain passed to various Kubernetes
+	// services. When MasterAPIDomain is empty value of
+	// Cluster.Kubernetes.API.Domain is passed.
+	//
+	// NOTE This is a work around limitation of Azure load balancers.
+	// Hopefully Load Balancer Standard SKU will allow to get rid of that.
+	//
+	// azure-operator sets that to 127.0.0.1. Other operators leave it empty.
+	MasterAPIDomain string
+	Cluster         v1alpha1.Cluster
 	// Hyperkube allows to pass extra `docker run` and `command` arguments
 	// to hyperkube image commands. This allows to e.g. add cloud provider
 	// extensions.
@@ -13,9 +26,23 @@ type Params struct {
 }
 
 type Hyperkube struct {
-	Apiserver         HyperkubeDocker
+	Apiserver         HyperkubeApiserver
 	ControllerManager HyperkubeDocker
 	Kubelet           HyperkubeDocker
+}
+
+type HyperkubeApiserver struct {
+	HyperkubeDocker
+
+	// BindAddress is a value of the --bind-address flag passed to the
+	// hyperkube apiserver. When BindAddress is empty value of
+	// `${DEFAULT_IPV4}` will be passed.
+	//
+	// NOTE This is a work around limitation of Azure load balancers.
+	// Hopefully Load Balancer Standard SKU will allow to get rid of that.
+	//
+	// azure-operator sets that to 0.0.0.0. Other operators leave it empty.
+	BindAddress string
 }
 
 type HyperkubeDocker struct {


### PR DESCRIPTION
In Azure load balancers backend pool nodes are not allowed to reach the load
balancer. Because of that we have to be able to specify different (loopback)
K8s apiserver address on master nodes.