### PR TITLE
v_3_0_0: add fine hyperkube types

### DIFF
--- a/v_3_0_0/types.go
+++ b/v_3_0_0/types.go
@@ -37,8 +37,8 @@ type Params struct {
 
 type Hyperkube struct {
 	Apiserver         HyperkubeApiserver
-	ControllerManager HyperkubeDocker
-	Kubelet           HyperkubeDocker
+	ControllerManager HyperkubeControllerManager
+	Kubelet           HyperkubeKubelet
 }
 
 type HyperkubeApiserver struct {

--- a/v_3_0_0/types.go
+++ b/v_3_0_0/types.go
@@ -42,8 +42,6 @@ type Hyperkube struct {
 }
 
 type HyperkubeApiserver struct {
-	HyperkubeDocker
-
 	// BindAddress is a value of the --bind-address flag passed to the
 	// hyperkube apiserver. When BindAddress is empty value of
 	// `${DEFAULT_IPV4}` will be passed.
@@ -53,6 +51,15 @@ type HyperkubeApiserver struct {
 	//
 	// azure-operator sets that to 0.0.0.0. Other operators leave it empty.
 	BindAddress string
+	Docker      HyperkubeDocker
+}
+
+type HyperkubeControllerManager struct {
+	Docker HyperkubeDocker
+}
+
+type HyperkubeKubelet struct {
+	Docker HyperkubeDocker
 }
 
 type HyperkubeDocker struct {


### PR DESCRIPTION
This makes initialization outline nicer.

See https://github.com/giantswarm/azure-operator/pull/79/commits/b5e04aa7c59e2af3d6cd311f79350e185839cc0d