### PR TITLE
v_2_0_0: Fix kubernetes audit logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ version directory, and then changes are introduced.
 
 ### Changed
 - Updated calico to 2.6.5.
+- Fix kubernetes audit logging
 
 ### Removed
 - Removed calico-ipip-pinger.

--- a/v_2_0_0/master_template.go
+++ b/v_2_0_0/master_template.go
@@ -1883,6 +1883,7 @@ coreos:
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/secrets/token_sign_key.pem:/etc/kubernetes/secrets/token_sign_key.pem \
       -v /etc/kubernetes/encryption/:/etc/kubernetes/encryption \
+      -v /var/log:/var/log \
       $IMAGE \
       /hyperkube apiserver \
       --allow_privileged=true \
@@ -1914,8 +1915,9 @@ coreos:
       --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
       --audit-log-path=/var/log/apiserver/audit.log \
       --audit-log-maxage=30 \
-      --audit-log-maxbackup=10 \
+      --audit-log-maxbackup=30 \
       --audit-log-maxsize=100 \
+      --feature-gates=AdvancedAuditing=false \
       --experimental-encryption-provider-config=/etc/kubernetes/encryption/k8s-encryption-config.yaml
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
One more exception to v2_0_0 as this is postmortem.

- Enable legacy audit logging. (It was disabled in 1.8 by default)
- Fix mounts for audit log
- Extend audit log size.

Part of https://github.com/giantswarm/giantswarm/issues/2346

Regarding size:
Audit log size is drowing REALLY FAST (1G of logs is 1.5 days in host cluster). My change limits maximum size to 3G (total we have ~6Gb root on master). Unfortunately we can not use logrotate compression, because of this [upstream bug](https://github.com/kubernetes/kubernetes/issues/52865). Anyway this is temporary solution. I hope central logging will come soon.

Change to v_3_0_0 with proper audit which is beta in 1.9 (not legacy) is coming.