### PR TITLE
v_3_0_0. Fixes audit log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ version directory, and then changes are introduced.
 - Update hyperkube to v1.9.0.
 - Use vanilla (previously coreos) hyperkube image.
 - kube-dns replaced with CoreDNS 1.0.1.
+- Fix Kubernetes API audit log.
 
 ### Removed
 - Remove calico-ipip-pinger.


### PR DESCRIPTION
- proper mounts
- add audit log policy (log all)
- allow to take max 3G for audit logs

Proper audit log policy should be done separately, probably as part of https://github.com/giantswarm/giantswarm/issues/1877