### PR TITLE
V201 fix audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ version directory, and then changes are introduced.
 - Remove calico-ipip-pinger.
 - Remove calico-node-controller.
 
+## [v2.0.1]
+
+### Changed
+- Fix audit logging.
+
 ## [v2.0.0]
 
 ### Added

--- a/v_2_0_1/master_template.go
+++ b/v_2_0_1/master_template.go
@@ -1883,6 +1883,7 @@ coreos:
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/secrets/token_sign_key.pem:/etc/kubernetes/secrets/token_sign_key.pem \
       -v /etc/kubernetes/encryption/:/etc/kubernetes/encryption \
+      -v /var/log:/var/log \
       $IMAGE \
       /hyperkube apiserver \
       --allow_privileged=true \
@@ -1914,8 +1915,9 @@ coreos:
       --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
       --audit-log-path=/var/log/apiserver/audit.log \
       --audit-log-maxage=30 \
-      --audit-log-maxbackup=10 \
+      --audit-log-maxbackup=30 \
       --audit-log-maxsize=100 \
+      --feature-gates=AdvancedAuditing=false \
       --experimental-encryption-provider-config=/etc/kubernetes/encryption/k8s-encryption-config.yaml
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
Enable legacy audit logging. (It was disabled in 1.8 by default)
Fix mounts for audit log
Extend audit log size.