### PR TITLE
Fix api-server bind address

### DIFF
--- a/v_3_1_1/master_template.go
+++ b/v_3_1_1/master_template.go
@@ -1806,7 +1806,7 @@ write_files:
         - --kubelet_https=true
         - --kubelet-preferred-address-types=InternalIP
         - --secure_port={{.Cluster.Kubernetes.API.SecurePort}}
-        - --bind-address=$(HOST_IP)
+        - --bind-address={{.Hyperkube.Apiserver.BindAddress}}
         - --etcd-prefix={{.Cluster.Etcd.Prefix}}
         - --profiling=false
         - --repair-malformed-updates=false
@@ -1819,7 +1819,7 @@ write_files:
         - --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem
         - --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem
         - --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem
-        - --advertise-address=$(HOST_IP)
+        - --advertise-address={{.Hyperkube.Apiserver.BindAddress}}
         - --runtime-config=api/all=true
         - --logtostderr=true
         - --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem

--- a/v_3_1_1/types.go
+++ b/v_3_1_1/types.go
@@ -5,6 +5,8 @@ import (
 )
 
 const (
+	// Default value references environment variable,
+	// defined inside api-server pod definition.
 	defaultHyperkubeApiserverBindAddress = "$(HOST_IP)"
 )
 

--- a/v_3_1_1/types.go
+++ b/v_3_1_1/types.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	defaultHyperkubeApiserverBindAddress = "${DEFAULT_IPV4}"
+	defaultHyperkubeApiserverBindAddress = "$(HOST_IP)"
 )
 
 type Params struct {


### PR DESCRIPTION
Previous change broke possibility for templating api-server bind address. This feature is required for `azure-operator` and blocks release of the new bundle. 