### PR TITLE
Fix etcd3 service StartLimitIntervalSec location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ version directory, and then changes are introduced.
 
 ### Changed
 - Change etcd data path to /var/lib/etcd.
+- Fix `StartLimitIntervalSec` parameter location in `etcd3` systemd unit.
 
 ## [v3.1.0]
 

--- a/v_3_1_1/master_template.go
+++ b/v_3_1_1/master_template.go
@@ -2145,9 +2145,9 @@ coreos:
       Requires=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
       Conflicts=etcd.service etcd2.service
+      StartLimitIntervalSec=0
 
       [Service]
-      StartLimitIntervalSec=0
       Restart=always
       RestartSec=0
       TimeoutStopSec=10


### PR DESCRIPTION
This parameter is located in wrong section (https://www.freedesktop.org/software/systemd/man/systemd.unit.html)