### PR TITLE
Add HostMount extension

### DIFF
--- a/v_3_1_1/master_template.go
+++ b/v_3_1_1/master_template.go
@@ -1903,6 +1903,9 @@ write_files:
         command:
         - /hyperkube
         - controller-manager
+        {{ range .Hyperkube.ControllerManager.Pod.CommandExtraArgs -}}
+        - {{ . }}
+        {{ end -}}
         - --logtostderr=true
         - --v=2
         - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}

--- a/v_3_1_1/master_template.go
+++ b/v_3_1_1/master_template.go
@@ -1796,7 +1796,7 @@ write_files:
         command:
         - /hyperkube
         - apiserver
-        {{ range .Hyperkube.Apiserver.Docker.CommandExtraArgs -}}
+        {{ range .Hyperkube.Apiserver.Pod.CommandExtraArgs -}}
         - {{ . }}
         {{ end -}}
         - --allow_privileged=true
@@ -1845,6 +1845,11 @@ write_files:
           hostPort: {{.Cluster.Kubernetes.API.SecurePort}}
           name: https
         volumeMounts:
+        {{ range .Hyperkube.Apiserver.Pod.HostExtraMounts -}}
+        - mountPath: {{ .Path }}
+          name: {{ .Name }}
+          readOnly: {{ .ReadOnly }}
+        {{ end -}}
         - mountPath: /var/log/apiserver/
           name: apiserver-log
         - mountPath: /etc/kubernetes/encryption/
@@ -1860,6 +1865,11 @@ write_files:
           name: ssl-certs-kubernetes
           readOnly: true
       volumes:
+      {{ range .Hyperkube.Apiserver.Pod.HostExtraMounts -}}
+      - hostPath: 
+          path: {{ .Path }}
+        name: {{ .Name }}
+      {{ end -}}
       - hostPath:
           path: /var/log/apiserver/
         name: apiserver-log
@@ -1913,6 +1923,11 @@ write_files:
           initialDelaySeconds: 15
           timeoutSeconds: 15
         volumeMounts:
+        {{ range .Hyperkube.ControllerManager.Pod.HostExtraMounts -}}
+        - mountPath: {{ .Path }}
+          name: {{ .Name }}
+          readOnly: {{ .ReadOnly }}
+        {{ end -}}
         - mountPath: /etc/kubernetes/config/
           name: k8s-config
           readOnly: true
@@ -1923,6 +1938,11 @@ write_files:
           name: ssl-certs-kubernetes
           readOnly: true
       volumes:
+      {{ range .Hyperkube.ControllerManager.Pod.HostExtraMounts -}}
+      - hostPath: 
+          path: {{ .Path }}
+        name: {{ .Name }}
+      {{ end -}}
       - hostPath:
           path: /etc/kubernetes/config
         name: k8s-config

--- a/v_3_1_1/master_template.go
+++ b/v_3_1_1/master_template.go
@@ -1845,7 +1845,7 @@ write_files:
           hostPort: {{.Cluster.Kubernetes.API.SecurePort}}
           name: https
         volumeMounts:
-        {{ range .Hyperkube.Apiserver.Pod.HostExtraMounts -}}
+        {{ range .Hyperkube.Apiserver.Pod.PodExtraMounts -}}
         - mountPath: {{ .Path }}
           name: {{ .Name }}
           readOnly: {{ .ReadOnly }}
@@ -1865,7 +1865,7 @@ write_files:
           name: ssl-certs-kubernetes
           readOnly: true
       volumes:
-      {{ range .Hyperkube.Apiserver.Pod.HostExtraMounts -}}
+      {{ range .Hyperkube.Apiserver.Pod.PodExtraMounts -}}
       - hostPath: 
           path: {{ .Path }}
         name: {{ .Name }}
@@ -1923,7 +1923,7 @@ write_files:
           initialDelaySeconds: 15
           timeoutSeconds: 15
         volumeMounts:
-        {{ range .Hyperkube.ControllerManager.Pod.HostExtraMounts -}}
+        {{ range .Hyperkube.ControllerManager.Pod.PodExtraMounts -}}
         - mountPath: {{ .Path }}
           name: {{ .Name }}
           readOnly: {{ .ReadOnly }}
@@ -1938,7 +1938,7 @@ write_files:
           name: ssl-certs-kubernetes
           readOnly: true
       volumes:
-      {{ range .Hyperkube.ControllerManager.Pod.HostExtraMounts -}}
+      {{ range .Hyperkube.ControllerManager.Pod.PodExtraMounts -}}
       - hostPath: 
           path: {{ .Path }}
         name: {{ .Name }}

--- a/v_3_1_1/master_template.go
+++ b/v_3_1_1/master_template.go
@@ -1845,7 +1845,7 @@ write_files:
           hostPort: {{.Cluster.Kubernetes.API.SecurePort}}
           name: https
         volumeMounts:
-        {{ range .Hyperkube.Apiserver.Pod.PodExtraMounts -}}
+        {{ range .Hyperkube.Apiserver.Pod.HyperkubePodHostExtraMounts -}}
         - mountPath: {{ .Path }}
           name: {{ .Name }}
           readOnly: {{ .ReadOnly }}
@@ -1865,7 +1865,7 @@ write_files:
           name: ssl-certs-kubernetes
           readOnly: true
       volumes:
-      {{ range .Hyperkube.Apiserver.Pod.PodExtraMounts -}}
+      {{ range .Hyperkube.Apiserver.Pod.HyperkubePodHostExtraMounts -}}
       - hostPath: 
           path: {{ .Path }}
         name: {{ .Name }}
@@ -1923,7 +1923,7 @@ write_files:
           initialDelaySeconds: 15
           timeoutSeconds: 15
         volumeMounts:
-        {{ range .Hyperkube.ControllerManager.Pod.PodExtraMounts -}}
+        {{ range .Hyperkube.ControllerManager.Pod.HyperkubePodHostExtraMounts -}}
         - mountPath: {{ .Path }}
           name: {{ .Name }}
           readOnly: {{ .ReadOnly }}
@@ -1938,7 +1938,7 @@ write_files:
           name: ssl-certs-kubernetes
           readOnly: true
       volumes:
-      {{ range .Hyperkube.ControllerManager.Pod.PodExtraMounts -}}
+      {{ range .Hyperkube.ControllerManager.Pod.HyperkubePodHostExtraMounts -}}
       - hostPath: 
           path: {{ .Path }}
         name: {{ .Name }}

--- a/v_3_1_1/types.go
+++ b/v_3_1_1/types.go
@@ -83,11 +83,11 @@ type HyperkubeDocker struct {
 }
 
 type HyperkubePod struct {
-	PodExtraMounts   []PodMount
-	CommandExtraArgs []string
+	HyperkubePodHostExtraMounts []HyperkubePodHostMount
+	CommandExtraArgs            []string
 }
 
-type PodMount struct {
+type HyperkubePodHostMount struct {
 	Name     string
 	Path     string
 	ReadOnly bool

--- a/v_3_1_1/types.go
+++ b/v_3_1_1/types.go
@@ -83,11 +83,11 @@ type HyperkubeDocker struct {
 }
 
 type HyperkubePod struct {
-	HostExtraMounts  []HostMount
+	PodExtraMounts   []PodMount
 	CommandExtraArgs []string
 }
 
-type HostMount struct {
+type PodMount struct {
 	Name     string
 	Path     string
 	ReadOnly bool

--- a/v_3_1_1/types.go
+++ b/v_3_1_1/types.go
@@ -42,7 +42,7 @@ type Hyperkube struct {
 }
 
 type HyperkubeApiserver struct {
-	Docker HyperkubeDocker
+	Pod HyperkubePod
 }
 
 type HyperkubeControllerManager struct {

--- a/v_3_1_1/types.go
+++ b/v_3_1_1/types.go
@@ -66,11 +66,11 @@ type HyperkubeApiserver struct {
 	//
 	// azure-operator sets that to 0.0.0.0. Other operators leave it empty.
 	BindAddress string
-	Docker      HyperkubeDocker
+	Pod         HyperkubePod
 }
 
 type HyperkubeControllerManager struct {
-	Docker HyperkubeDocker
+	Pod HyperkubePod
 }
 
 type HyperkubeKubelet struct {
@@ -80,6 +80,17 @@ type HyperkubeKubelet struct {
 type HyperkubeDocker struct {
 	RunExtraArgs     []string
 	CommandExtraArgs []string
+}
+
+type HyperkubePod struct {
+	HostExtraMounts  []HostMount
+	CommandExtraArgs []string
+}
+
+type HostMount struct {
+	Name     string
+	Path     string
+	ReadOnly bool
 }
 
 type FileMetadata struct {


### PR DESCRIPTION
With selfhosted components, we need another way to add custom mounts. This is how I see we can do it. Naming is not that god, but for now I'm just testing stuff here: https://github.com/giantswarm/azure-operator/pull/122 . With this configuration I'm able to run k8s components as selfhosted. There are still some other issues, so this is only a part of a change