### PR TITLE
Protect kubernetes key pods from eviction

### DIFF
--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -33,7 +33,7 @@ write_files:
             app: calico-ipip-pinger
         spec:
           serviceAccountName: calico-node
-	  priorityClassName: critical-pods
+          priorityClassName: critical-pods
           containers:
           - name: calico-ipip-pinger
             image: quay.io/giantswarm/calico-ipip-pinger:c2d40fb9bd4dcd78fd28b897f43b2d9a744ab374
@@ -195,7 +195,7 @@ write_files:
             operator: Exists
             effect: NoSchedule
           hostNetwork: true
-	  priorityClassName: critical-pods
+          priorityClassName: critical-pods
           serviceAccountName: calico-node
           # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
           # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
@@ -380,7 +380,7 @@ write_files:
           # The controllers must run in the host network namespace so that
           # it isn't governed by policy that would prevent it from working.
           hostNetwork: true
-	  priorityClassName: critical-pods
+          priorityClassName: critical-pods
           serviceAccountName: calico-kube-controllers
           containers:
             - name: calico-kube-controllers
@@ -517,7 +517,7 @@ write_files:
             k8s-app: coredns
         spec:
           serviceAccountName: coredns
-	  priorityClassName: important-pods
+          priorityClassName: important-pods
           tolerations:
             - key: node-role.kubernetes.io/master
               effect: NoSchedule
@@ -711,7 +711,7 @@ write_files:
                         - nginx-ingress-controller
                   topologyKey: kubernetes.io/hostname
           serviceAccountName: nginx-ingress-controller
-	  priorityClassName: important-pods
+          priorityClassName: important-pods
           initContainers:
           - command:
             - sh
@@ -835,7 +835,7 @@ write_files:
             operator: Exists
             effect: NoSchedule
           hostNetwork: true
-	  priorityClassName: critical-pods
+          priorityClassName: critical-pods
           serviceAccountName: kube-proxy
           containers:
             - name: kube-proxy

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -1573,7 +1573,7 @@ write_files:
        apiGroup: rbac.authorization.k8s.io
        kind: ClusterRole
        name: restricted-psp-user
-- path: /srv/priority_classes.ayml
+- path: /srv/priority_classes.yaml
   permissions: 0544
   content:
     apiVersion: scheduling.k8s.io/v1alpha1
@@ -1651,6 +1651,18 @@ write_files:
               [ "$?" -ne "0" ]
           do
               echo "failed to apply /src/$manifest, retrying in 5 sec"
+              sleep 5s
+          done
+      done
+
+      PRIORITY_CLASSES="priority_classes.yaml"
+      # create priority classes
+      do
+          while
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$PRIORITY_CLASSES
+             [ "$?" -ne "0" ]
+          do
+              echo "failed to apply /src/$PRIORITY_CLASSES, retrying in 5 sec"
               sleep 5s
           done
       done

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -1925,9 +1925,7 @@ write_files:
         - --repair-malformed-updates=false
         - --service-account-lookup=true
         - --authorization-mode=RBAC
-        - --feature-gates=ExpandPersistentVolumes=true
-        - --feature-gates=PodPriority=true
-        - --runtime-config=scheduling.k8s.io/v1alpha1=true
+        - --feature-gates=ExpandPersistentVolumes=true,PodPriority=true
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy,Priority
         - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
         - --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}}
@@ -1936,7 +1934,7 @@ write_files:
         - --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem
         - --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem
         - --advertise-address=$(HOST_IP)
-        - --runtime-config=api/all=true
+        - --runtime-config=api/all=true,scheduling.k8s.io/v1alpha1=true
         - --logtostderr=true
         - --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
         - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -275,10 +275,10 @@ write_files:
               resources:
                 requests:
                   cpu: 250m
-		  memory: 100Mi
-		limits:
-		  cpu: 250m
-		  memory: 100Mi
+                  memory: 100Mi
+                limits:
+                  cpu: 250m
+                  memory: 100Mi
               livenessProbe:
                 httpGet:
                   path: /liveness
@@ -417,9 +417,9 @@ write_files:
                 requests:
                   cpu: 30m
                   memory: 90Mi
-		limits:
-		  cpu: 30m
-		  memory: 90Mi
+                limits:
+                  cpu: 30m
+                  memory: 90Mi
               volumeMounts:
                 # Mount in the etcd TLS secrets.
                 - mountPath: /etc/kubernetes/ssl/etcd
@@ -858,9 +858,9 @@ write_files:
                 requests:
                   memory: "80Mi"
                   cpu: "75m"
-		limits:
-		  memory: "80Mi"
-		  cpu: "75m"
+                limits:
+                  memory: "80Mi"
+                  cpu: "75m"
               securityContext:
                 privileged: true
               volumeMounts:
@@ -1926,7 +1926,9 @@ write_files:
         - --service-account-lookup=true
         - --authorization-mode=RBAC
         - --feature-gates=ExpandPersistentVolumes=true
-        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy
+        - --feature-gates=PodPriority=true
+        - --runtime-config=scheduling.k8s.io/v1alpha1=true
+        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy,Priority
         - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
         - --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}}
         - --etcd-servers=https://127.0.0.1:2379
@@ -1949,10 +1951,10 @@ write_files:
         resources:
           requests:
             cpu: 300m
-	    memory: 300Mi
-	  limits:
-	    cpu: 300m
-	    memory: 300Mi
+            memory: 300Mi
+          limits:
+            cpu: 300m
+            memory: 300Mi
         livenessProbe:
           tcpSocket:
             port: {{.Cluster.Kubernetes.API.SecurePort}}
@@ -2037,10 +2039,10 @@ write_files:
         resources:
           requests:
             cpu: 200m
-	    memory: 200Mi
-	  limits:
-	    cpu: 200m
-	    memory: 200Mi
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
         livenessProbe:
           httpGet:
             host: 127.0.0.1
@@ -2100,15 +2102,16 @@ write_files:
         - --logtostderr=true
         - --v=2
         - --profiling=false
+        - --feature-gates=PodPriority=true
         - --kubeconfig=/etc/kubernetes/config/scheduler-kubeconfig.yml
         resources:
           requests:
             cpu: 100m
-	    memory: 100Mi
+            memory: 100Mi
           limits:
             cpu: 100m
-	    memory: 100Mi
-	livenessProbe:
+            memory: 100Mi
+        livenessProbe:
           httpGet:
             host: 127.0.0.1
             path: /healthz
@@ -2457,6 +2460,7 @@ coreos:
       --register-node=true \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
       --allow-privileged=true \
+      --feature-gates=PodPriority=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
       --node-labels="node-role.kubernetes.io/master,role=master,kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -1905,6 +1905,10 @@ write_files:
         resources:
           requests:
             cpu: 300m
+	    memory: 300Mi
+	  limits:
+	    cpu: 300m
+	    memory: 300Mi
         livenessProbe:
           tcpSocket:
             port: {{.Cluster.Kubernetes.API.SecurePort}}
@@ -1988,6 +1992,10 @@ write_files:
         resources:
           requests:
             cpu: 200m
+	    memory: 200Mi
+	  limits:
+	    cpu: 200m
+	    memory: 200Mi
         livenessProbe:
           httpGet:
             host: 127.0.0.1
@@ -2050,7 +2058,11 @@ write_files:
         resources:
           requests:
             cpu: 100m
-        livenessProbe:
+	    memory: 100Mi
+          limits:
+            cpu: 100m
+	    memory: 100Mi
+	livenessProbe:
           httpGet:
             host: 127.0.0.1
             path: /healthz

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -277,6 +277,10 @@ write_files:
               resources:
                 requests:
                   cpu: 250m
+		  memory: 100Mi
+		limits:
+		  cpu: 250m
+		  memory: 100Mi
               livenessProbe:
                 httpGet:
                   path: /liveness
@@ -418,6 +422,9 @@ write_files:
                 requests:
                   cpu: 30m
                   memory: 90Mi
+		limits:
+		  cpu: 30m
+		  memory: 90Mi
               volumeMounts:
                 # Mount in the etcd TLS secrets.
                 - mountPath: /etc/kubernetes/ssl/etcd

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -1655,16 +1655,12 @@ write_files:
           done
       done
 
-      PRIORITY_CLASSES="priority_classes.yaml"
-      # create priority classes
+      while
+          /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/priority_classes.yaml
+          [ "$?" -ne "0" ]
       do
-          while
-              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$PRIORITY_CLASSES
-             [ "$?" -ne "0" ]
-          do
-              echo "failed to apply /src/$PRIORITY_CLASSES, retrying in 5 sec"
-              sleep 5s
-          done
+          echo "failed to apply /src/priority_classes.yaml, retrying in 5 sec"
+          sleep 5s
       done
 
       {{ if not .DisableCalico -}}

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -1574,8 +1574,8 @@ write_files:
        kind: ClusterRole
        name: restricted-psp-user
 - path: /srv/priority_classes.yaml
-  permissions: 0544
-  content:
+  permissions: 0644
+  content: |
     apiVersion: scheduling.k8s.io/v1alpha1
     kind: PriorityClass
     metadata:

--- a/v_3_2_1/master_template.go
+++ b/v_3_2_1/master_template.go
@@ -861,6 +861,9 @@ write_files:
                 requests:
                   memory: "80Mi"
                   cpu: "75m"
+		limits:
+		  memory: "80Mi"
+		  cpu: "75m"
               securityContext:
                 privileged: true
               volumeMounts:

--- a/v_3_2_1/worker_template.go
+++ b/v_3_2_1/worker_template.go
@@ -304,6 +304,7 @@ coreos:
       --network-plugin=cni \
       --register-node=true \
       --allow-privileged=true \
+      --feature-gates=PodPriority=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
       --node-labels="kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --kube-reserved="cpu=200m,memory=250Mi" \


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/2634

- [x] assign k8s cluster components pods `Guaranteed` qos
  - [x] api-server
  - [x] scheduler
  - [x] controller-manager
- [x] assign critical pods `Guaranteed` qos
  - [x] kube-proxy ds
  - [x] calico-node
  - [x] kube-controller
- [x] create priority classes
  - [x] high priority for cluster components
  - [x] high-1 for critical pods
  - [x] default for others
- [x] apply priority classes for pods
