### PR TITLE
Remove calico ipip pinger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ version directory, and then changes are introduced.
 
 ## [v3.2.5] WIP
 
-### Changed
-- Add your change here.
+### Removed
+- Removed calico-ipip-pinger.
 
 
 

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -11,75 +11,6 @@ users:
 {{end}}
 write_files:
 {{ if not .DisableCalico -}}
-- path: /srv/calico-ipip-pinger-ds.yaml
-  owner: root
-  permissions: 644
-  content: |
-    apiVersion: extensions/v1beta1
-    kind: DaemonSet
-    metadata:
-      labels:
-        app: calico-ipip-pinger
-      name: calico-ipip-pinger
-      namespace: kube-system
-    spec:
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-      template:
-        metadata:
-          labels:
-            app: calico-ipip-pinger
-        spec:
-          serviceAccountName: calico-node
-          priorityClassName: critical-pods
-          containers:
-          - name: calico-ipip-pinger
-            image: quay.io/giantswarm/calico-ipip-pinger:c2d40fb9bd4dcd78fd28b897f43b2d9a744ab374
-            imagePullPolicy: Always
-            securityContext:
-              privileged: true
-            env:
-              # The location of the Calico etcd cluster.
-              - name: ETCD_ENDPOINTS
-                valueFrom:
-                  configMapKeyRef:
-                    name: calico-config
-                    key: etcd_endpoints
-              # Location of the CA certificate for etcd.
-              - name: ETCD_CA_CERT_FILE
-                valueFrom:
-                  configMapKeyRef:
-                    name: calico-config
-                    key: etcd_ca
-              # Location of the client key for etcd.
-              - name: ETCD_KEY_FILE
-                valueFrom:
-                  configMapKeyRef:
-                    name: calico-config
-                    key: etcd_key
-              # Location of the client certificate for etcd.
-              - name: ETCD_CERT_FILE
-                valueFrom:
-                  configMapKeyRef:
-                    name: calico-config
-                    key: etcd_cert
-            volumeMounts:
-              # Mount in the etcd TLS secrets.
-              - mountPath: /etc/kubernetes/ssl/etcd
-                name: etcd-certs
-          volumes:
-            # Mount in the etcd TLS secrets.
-            - name: etcd-certs
-              hostPath:
-                path: /etc/kubernetes/ssl/etcd
-          tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-            operator: Exists
-          hostNetwork: true
-          restartPolicy: Always
 - path: /srv/calico-kube-controllers-sa.yaml
   owner: root
   permissions: 644
@@ -1654,7 +1585,6 @@ write_files:
       CALICO_FILES="${CALICO_FILES} calico-kube-controllers-sa.yaml"
       CALICO_FILES="${CALICO_FILES} calico-ds.yaml"
       CALICO_FILES="${CALICO_FILES} calico-kube-controllers.yaml"
-      CALICO_FILES="${CALICO_FILES} calico-ipip-pinger-ds.yaml"
 
       for manifest in $CALICO_FILES
       do


### PR DESCRIPTION
Finally we can remove ipip pinger, i've checked and guest clusters actually already have rule to allow ALL traffic (including protocol 4 - IPv4 encapsulation) between master and workers.