### PR TITLE
Disable etcd3-defragmentation service in favor timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ version directory, and then changes are introduced.
 ## [v3.2.5] WIP
 
 ### Changed
-- Add your change here.
+- Disabled etcd3-defragmentation service in favor systemd timer.
 
 
 

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -2313,8 +2313,7 @@ coreos:
       [Install]
       WantedBy=multi-user.target
   - name: etcd3-defragmentation.service
-    enable: true
-    command: start
+    enable: false
     content: |
       [Unit]
       Description=etcd defragmentation job


### PR DESCRIPTION
We manage this service by timer, so we don't want it to be started on boot. Starting it on boot causes race conditions sometimes, because systemd will start etcd3-defragmentation immediately after etcd3, so etcd3 was not be able to start.

similar to: https://github.com/giantswarm/giantnetes-terraform/pull/59