### PR TITLE
v_3_2_5: Add /lib/modules mount for kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ version directory, and then changes are introduced.
 - Update hyperkube to version 1.10.1.
 - Changed kubelet bind mount mode from "shared" to "rshared".
 - Disabled etcd3-defragmentation service in favor systemd timer.
+- Added /lib/modules mount for kubelet.
 
 ### Removed
 - Removed docker flag "--disable-legacy-registry".

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -2328,6 +2328,7 @@ coreos:
       -v /etc/iscsi/:/etc/iscsi/ \
       -v /dev/disk/by-path/:/dev/disk/by-path/ \
       -v /dev/mapper/:/dev/mapper/ \
+      -v /lib/modules:/lib/modules \
       -v /usr/sbin/mkfs.xfs:/usr/sbin/mkfs.xfs \
       -v /usr/lib64/libxfs.so.0:/usr/lib/libxfs.so.0 \
       -v /usr/lib64/libxcmd.so.0:/usr/lib/libxcmd.so.0 \

--- a/v_3_2_5/worker_template.go
+++ b/v_3_2_5/worker_template.go
@@ -275,6 +275,7 @@ coreos:
       -v /etc/iscsi/:/etc/iscsi/ \
       -v /dev/disk/by-path/:/dev/disk/by-path/ \
       -v /dev/mapper/:/dev/mapper/ \
+      -v /lib/modules:/lib/modules \
       -v /usr/sbin/mkfs.xfs:/usr/sbin/mkfs.xfs \
       -v /usr/lib64/libxfs.so.0:/usr/lib/libxfs.so.0 \
       -v /usr/lib64/libxcmd.so.0:/usr/lib/libxcmd.so.0 \


### PR DESCRIPTION
This allows to use iscsi volumes. Kubelet needs iscsi_tcp module.