### PR TITLE
v_3_2_5: Updated CoreDNS to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ version directory, and then changes are introduced.
 - Changed kubelet bind mount mode from "shared" to "rshared".
 - Disabled etcd3-defragmentation service in favor systemd timer.
 - Added /lib/modules mount for kubelet.
+- Updated CoreDNS to 1.1.1.
 
 ### Removed
 - Removed docker flag "--disable-legacy-registry".

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -412,7 +412,8 @@ write_files:
             health
             kubernetes {{.Cluster.Kubernetes.Domain}} {{.Cluster.Kubernetes.API.ClusterIPRange}} {{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}} {
               pods insecure
-              upstream /etc/resolv.conf
+              upstream
+              fallthrough in-addr.arpa ip6.arpa
             }
             prometheus :9153
             proxy . /etc/resolv.conf
@@ -460,7 +461,7 @@ write_files:
                   topologyKey: kubernetes.io/hostname
           containers:
           - name: coredns
-            image: quay.io/giantswarm/coredns:1.0.6
+            image: quay.io/giantswarm/coredns:1.1.1
             imagePullPolicy: IfNotPresent
             args: [ "-conf", "/etc/coredns/Corefile" ]
             volumeMounts:


### PR DESCRIPTION
There was [regression](https://github.com/coredns/coredns/issues/1532) in CoreDNS that caused broken e2e conformance tests for DNS [here](https://github.com/giantswarm/giantnetes-terraform/pull/68#issuecomment-381061326).

Initial change: https://github.com/giantswarm/giantnetes-terraform/pull/72