### PR TITLE
v_3_2_5: updated Calico to 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ version directory, and then changes are introduced.
 - Disabled etcd3-defragmentation service in favor systemd timer.
 - Added /lib/modules mount for kubelet.
 - Updated CoreDNS to 1.1.1.
+- Updated Calico to 3.0.5.
 
 ### Removed
 - Removed docker flag "--disable-legacy-registry".

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -33,12 +33,12 @@ write_files:
   owner: root
   permissions: 644
   content: |
-    # Calico Version v3.0.2
-    # https://docs.projectcalico.org/v3.0/releases#v3.0.2
+    # Calico Version v3.0.5
+    # https://docs.projectcalico.org/v3.0/releases#v3.0.5
     # This manifest includes the following component versions:
-    #   calico/node:v3.0.2
-    #   calico/cni:v2.0.0
-    #   calico/kube-controllers:v2.0.0
+    #   calico/node:v3.0.5
+    #   calico/cni:v2.0.4
+    #   calico/kube-controllers:v2.0.3
 
     # This ConfigMap is used to configure a self-hosted Calico installation.
     kind: ConfigMap
@@ -136,7 +136,7 @@ write_files:
             # container programs network policy and routes on each
             # host.
             - name: calico-node
-              image: quay.io/calico/node:v3.0.2
+              image: quay.io/calico/node:v3.0.5
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -231,7 +231,7 @@ write_files:
             # This container installs the Calico CNI binaries
             # and CNI network config file on each node.
             - name: install-cni
-              image: quay.io/calico/cni:v2.0.0
+              image: quay.io/calico/cni:v2.0.4
               command: ["/install-cni.sh"]
               env:
                 # Name of the CNI config file to create.
@@ -312,7 +312,7 @@ write_files:
           serviceAccountName: calico-kube-controllers
           containers:
             - name: calico-kube-controllers
-              image: quay.io/calico/kube-controllers:v2.0.0
+              image: quay.io/calico/kube-controllers:v2.0.3
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS


### PR DESCRIPTION
There were number of bugfixes from 3.0.2

https://docs.projectcalico.org/v3.0/releases/