### PR TITLE
Check for empty public key

### DIFF
--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -6,8 +6,10 @@ users:
     groups:
       - "sudo"
       - "docker"
+{{ if ne $user.PublicKey "" }}
     ssh-authorized-keys:
        - "{{ $user.PublicKey }}"
+{{ end }}
 {{end}}
 write_files:
 {{ if not .DisableCalico -}}

--- a/v_3_2_5/worker_template.go
+++ b/v_3_2_5/worker_template.go
@@ -6,8 +6,10 @@ users:
     groups:
       - "sudo"
       - "docker"
+{{ if ne $user.PublicKey "" }}
     ssh-authorized-keys:
        - "{{ $user.PublicKey }}"
+{{ end }}
 {{end}}
 write_files:
 - path: /etc/kubernetes/config/proxy-kubeconfig.yml


### PR DESCRIPTION
`giantswarm` user for sso does not have public key to be configured during node provisioning