### PR TITLE
v_3_2_5: Disable SSL passthrough in nginx-ingress-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ version directory, and then changes are introduced.
 - Updated Calico to 3.0.5.
 - Updated Etcd to 3.3.3.
 - Added trusted certificate CNs to aggregation API allowed names.
+- Disabled SSL passthrough in nginx-ingress-controller.
 
 ### Removed
 - Removed docker flag "--disable-legacy-registry".

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -654,7 +654,6 @@ write_files:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
             - --configmap=$(POD_NAMESPACE)/ingress-nginx
-            - --enable-ssl-passthrough
             - --annotations-prefix=nginx.ingress.kubernetes.io
             env:
               - name: POD_NAME


### PR DESCRIPTION
This change disables unnecessary built-in SSL proxying.

Tested in `gauss`. SSL passthru still works fine.

With this change we still can use SSL passthru, because we have AWS ELB proxy protocol enabled. In case, of KVM/Azure we also need to have proxy protocol enabled in external load balancer. Enabling this flag in nginx-ingress-controller only makes sense if no external load balancer if used.

See my comment for details: https://github.com/kubernetes/ingress-nginx/issues/2354#issuecomment-382757307

Fixes: https://github.com/giantswarm/giantswarm/issues/2948