### PR TITLE
add master/worker CNs to aggregator allowed names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ version directory, and then changes are introduced.
 - Updated CoreDNS to 1.1.1.
 - Updated Calico to 3.0.5.
 - Updated Etcd to 3.3.3.
+- Added trusted certificate CNs to aggregation API allowed names.
 
 ### Removed
 - Removed docker flag "--disable-legacy-registry".

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -1865,7 +1865,7 @@ write_files:
         - --audit-policy-file=/etc/kubernetes/manifests/audit-policy.yml
         - --experimental-encryption-provider-config=/etc/kubernetes/encryption/k8s-encryption-config.yaml
         - --requestheader-client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
-        - --requestheader-allowed-names=aggregator
+        - --requestheader-allowed-names=aggregator,{{.Cluster.Kubernetes.API.Domain}},{{.Cluster.Kubernetes.Kubelet.Domain}}
         - --requestheader-extra-headers-prefix=X-Remote-Extra-
         - --requestheader-group-headers=X-Remote-Group
         - --requestheader-username-headers=X-Remote-User


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/2973

TLDR:
We reuse our CA and certs for aggregation API thus we need to allow at least for the known CNs (master and worker certs) which are the two templated domains I added so that aggregation API and services that use it do not log errors all the time (see PM)