### PR TITLE
v_3_2_5: Remove explicit hostname labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ version directory, and then changes are introduced.
 - Updated Etcd to 3.3.3.
 - Added trusted certificate CNs to aggregation API allowed names.
 - Disabled SSL passthrough in nginx-ingress-controller.
+- Removed explicit hostname labeling for kubelet.
 
 ### Removed
 - Removed docker flag "--disable-legacy-registry".

--- a/v_3_2_5/master_template.go
+++ b/v_3_2_5/master_template.go
@@ -2398,7 +2398,7 @@ coreos:
       --feature-gates=ExpandPersistentVolumes=true,PodPriority=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
-      --node-labels="node-role.kubernetes.io/master,role=master,kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="node-role.kubernetes.io/master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --kube-reserved="cpu=200m,memory=250Mi" \
       --system-reserved="cpu=150m,memory=250Mi" \
       --enforce-node-allocatable=pods \

--- a/v_3_2_5/worker_template.go
+++ b/v_3_2_5/worker_template.go
@@ -308,7 +308,7 @@ coreos:
       --allow-privileged=true \
       --feature-gates=ExpandPersistentVolumes=true,PodPriority=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
-      --node-labels="kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --kube-reserved="cpu=200m,memory=250Mi" \
       --system-reserved="cpu=150m,memory=250Mi" \
       --enforce-node-allocatable=pods \

--- a/v_3_2_6/master_template.go
+++ b/v_3_2_6/master_template.go
@@ -2398,7 +2398,7 @@ coreos:
       --feature-gates=ExpandPersistentVolumes=true,PodPriority=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
-      --node-labels="node-role.kubernetes.io/master,role=master,kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="node-role.kubernetes.io/master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --kube-reserved="cpu=200m,memory=250Mi" \
       --system-reserved="cpu=150m,memory=250Mi" \
       --enforce-node-allocatable=pods \

--- a/v_3_2_6/worker_template.go
+++ b/v_3_2_6/worker_template.go
@@ -308,7 +308,7 @@ coreos:
       --allow-privileged=true \
       --feature-gates=ExpandPersistentVolumes=true,PodPriority=true \
       --kubeconfig=/etc/kubernetes/config/kubelet-kubeconfig.yml \
-      --node-labels="kubernetes.io/hostname=${HOSTNAME},ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --kube-reserved="cpu=200m,memory=250Mi" \
       --system-reserved="cpu=150m,memory=250Mi" \
       --enforce-node-allocatable=pods \


### PR DESCRIPTION
This is exception for already freezed 3.2.5 release.

Problem that it was broken for a while (from beginning?). We either can remove brackets `{}` to let systemd handle environment variable (still not clear why brackets break this) or remove explicit label setup completely. I've tested in kvm/azure/aws and kubelet properly detects hostname.

Fixes: https://github.com/giantswarm/giantswarm/issues/2999