### PR TITLE
sync privileged psp with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ version directory, and then changes are introduced.
 ### Changed
 - Changed node-exporter to have named ports.
 - Added RBAC rules for configmaps, secrets and hpa for kube-state-metrics.
+- Synced privileged PSP with upstream (adding all added capabilities and seccomp profiles)
 
 ### Removed
 

--- a/v_3_2_6/master_template.go
+++ b/v_3_2_6/master_template.go
@@ -1419,8 +1419,12 @@ write_files:
     kind: PodSecurityPolicy
     metadata:
       name: privileged
+      annotations:
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     spec:
       allowPrivilegeEscalation: true
+      allowedCapabilities:
+      - '*'
       fsGroup:
         rule: RunAsAny
       privileged: true
@@ -1436,7 +1440,7 @@ write_files:
       hostIPC: true
       hostNetwork: true
       hostPorts:
-      - min: 1
+      - min: 0
         max: 65536
     ---
     apiVersion: extensions/v1beta1


### PR DESCRIPTION
see https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies

this is so that privileged can be used for a more extended security context, in our docs we commend not to use this but to use a narrower one based on restricted psp.