### PR TITLE
Add versioning part to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 
 # k8scloudconfig
 Cloud-init configuration for setting up Kubernetes clusters
+
+# Versioning
+
+k8scloudconfig library uses semver versioning scheme. Please follow simple rules, when creating new version:
+
+1. Increment MAJOR version number when breaking library API changes introduced.
+2. Increment PATCH version number for critical bug fixes. Patch release needs to be immediately included into patch release of operator.
+3. Increment MINOR version number for all other changes.
+4. WIP releases are only possible for major and minor version updates. Patch releases should be immediately freezed.
+
+Examples:
+- "Hyperkube upgrade from 1.9.5 to 1.10.1" is a minor version upgrade.
+- "New field `DisableCalico` added to `Params` struct" is a major version upgrade.
+- "Kubelet configuration changed to prevent stuck in terminating state pods" is a patch version upgrade.


### PR DESCRIPTION
Define versioning rules for k8scc taking into account feedback i got after trying to create patch release for aws-operator https://github.com/giantswarm/aws-operator/pull/921