### PR TITLE
Remove kube-state-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ version directory, and then changes are introduced.
 - Updated hyperkube to version 1.10.2.
 
 ### Removed
+- Removed kube-state-metrics related components (will be managed by
+chart-operator).
 
 
 ## [v3.2.6]

--- a/v_3_3_0/master_template.go
+++ b/v_3_3_0/master_template.go
@@ -965,77 +965,6 @@ write_files:
           hostPID: true
           securityContext:
             runAsUser: 0
-- path: /srv/kube-state-metrics-svc.yaml
-  owner: root
-  permissions: 0644
-  content: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: kube-state-metrics
-      namespace: kube-system
-      labels:
-        app: kube-state-metrics
-      annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/scheme: "http"
-    spec:
-      ports:
-      - port: 10301
-      selector:
-        app: kube-state-metrics
-- path: /srv/kube-state-metrics-sa.yaml
-  owner: root
-  permissions: 0644
-  content: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: kube-state-metrics
-      namespace: kube-system
-      labels:
-        app: kube-state-metrics
-- path: /srv/kube-state-metrics-dep.yaml
-  owner: root
-  permissions: 0644
-  content: |
-    apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      name: kube-state-metrics
-      namespace: kube-system
-      labels:
-        app: kube-state-metrics
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: kube-state-metrics
-        spec:
-          containers:
-          - name: kube-state-metrics
-            image: quay.io/giantswarm/kube-state-metrics:v1.3.1
-            args:
-              - '--port=10301'
-            livenessProbe:
-              httpGet:
-                path: /
-                port: 10301
-              initialDelaySeconds: 5
-              timeoutSeconds: 5
-            readinessProbe:
-              httpGet:
-                path: /
-                port: 10301
-              initialDelaySeconds: 5
-              timeoutSeconds: 5
-            resources:
-              requests:
-                cpu: 50m
-                memory: 75Mi
-          serviceAccountName: kube-state-metrics
-          hostNetwork: true
 - path: /srv/rbac_bindings.yaml
   owner: root
   permissions: 0644
@@ -1177,21 +1106,6 @@ write_files:
     roleRef:
       kind: Role
       name: node-exporter
-      apiGroup: rbac.authorization.k8s.io
-    ---
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: kube-state-metrics
-      labels:
-        app: kube-state-metrics
-    subjects:
-      - kind: ServiceAccount
-        name: kube-state-metrics
-        namespace: kube-system
-    roleRef:
-      kind: ClusterRole
-      name: kube-state-metrics
       apiGroup: rbac.authorization.k8s.io
 - path: /srv/rbac_roles.yaml
   owner: root
@@ -1345,72 +1259,6 @@ write_files:
       verbs:     ['use']
       resourceNames:
       - privileged
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: kube-state-metrics
-      labels:
-        app: kube-state-metrics
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-          - pods
-          - services
-          - resourcequotas
-          - replicationcontrollers
-          - limitranges
-          - persistentvolumeclaims
-          - persistentvolumes
-          - namespaces
-          - endpoints
-          - secrets
-          - configmaps
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - extensions
-        resources:
-          - daemonsets
-          - deployments
-          - replicasets
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - apps
-        resources:
-          - statefulsets
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - batch
-        resources:
-          - cronjobs
-          - jobs
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - extensions
-        resources:
-          - podsecuritypolicies
-        verbs:
-          - use
-        resourceNames:
-          - privileged
-      - apiGroups:
-          - autoscaling
-        attributeRestrictions: null
-        resources:
-          - horizontalpodautoscalers
-        verbs:
-          - list
-          - watch
 - path: /srv/psp_policies.yaml
   owner: root
   permissions: 0644
@@ -1697,9 +1545,6 @@ write_files:
       MANIFESTS="${MANIFESTS} node-exporter-svc.yaml"
       MANIFESTS="${MANIFESTS} node-exporter-sa.yaml"
       MANIFESTS="${MANIFESTS} node-exporter-ds.yaml"
-      MANIFESTS="${MANIFESTS} kube-state-metrics-svc.yaml"
-      MANIFESTS="${MANIFESTS} kube-state-metrics-sa.yaml"
-      MANIFESTS="${MANIFESTS} kube-state-metrics-dep.yaml"
 
       for manifest in $MANIFESTS
       do


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

The component is hosted in https://github.com/giantswarm/kubernetes-kube-state-metrics/. It will be managed by chart-operator as part of the managed services story. 