### PR TITLE
 v_3_3_1: switch hyperkube to v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ version directory, and then changes are introduced.
 - Changed some remaining images to be pulled from Giant Swarm's registry
 - Updated Alpine sidecar for Ingress Controller to version 3.7
 - Fixed mkfs.xfs for containerized kubelet.
+- Updated hyperkube to version 1.10.3.
 
 ## [v3.3.0]
 

--- a/v_3_3_1/cloudconfig.go
+++ b/v_3_3_1/cloudconfig.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"bytes"

--- a/v_3_3_1/cloudconfig_test.go
+++ b/v_3_3_1/cloudconfig_test.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"encoding/base64"

--- a/v_3_3_1/common_template_test.go
+++ b/v_3_3_1/common_template_test.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 type nopWriter struct{}
 

--- a/v_3_3_1/error.go
+++ b/v_3_3_1/error.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import "github.com/giantswarm/microerror"
 

--- a/v_3_3_1/master_template.go
+++ b/v_3_3_1/master_template.go
@@ -763,7 +763,7 @@ write_files:
           serviceAccountName: kube-proxy
           containers:
             - name: kube-proxy
-              image: quay.io/giantswarm/hyperkube:v1.10.2
+              image: quay.io/giantswarm/hyperkube:v1.10.3
               command:
               - /hyperkube
               - proxy
@@ -1716,7 +1716,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-api-server
-        image: quay.io/giantswarm/hyperkube:v1.10.2
+        image: quay.io/giantswarm/hyperkube:v1.10.3
         env:
         - name: HOST_IP
           valueFrom:
@@ -1838,7 +1838,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-controller-manager
-        image: quay.io/giantswarm/hyperkube:v1.10.2
+        image: quay.io/giantswarm/hyperkube:v1.10.3
         command:
         - /hyperkube
         - controller-manager
@@ -1911,7 +1911,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-scheduler
-        image: quay.io/giantswarm/hyperkube:v1.10.2
+        image: quay.io/giantswarm/hyperkube:v1.10.3
         command:
         - /hyperkube
         - scheduler
@@ -2199,7 +2199,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.3"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_3_1/master_template.go
+++ b/v_3_3_1/master_template.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 const MasterTemplate = `#cloud-config
 users:

--- a/v_3_3_1/master_template_test.go
+++ b/v_3_3_1/master_template_test.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"testing"

--- a/v_3_3_1/render_asset_content.go
+++ b/v_3_3_1/render_asset_content.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"bytes"

--- a/v_3_3_1/render_asset_content_test.go
+++ b/v_3_3_1/render_asset_content_test.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"testing"

--- a/v_3_3_1/types.go
+++ b/v_3_3_1/types.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"

--- a/v_3_3_1/worker_template.go
+++ b/v_3_3_1/worker_template.go
@@ -248,7 +248,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.3"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_3_1/worker_template.go
+++ b/v_3_3_1/worker_template.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 const WorkerTemplate = `#cloud-config
 users:

--- a/v_3_3_1/worker_template_test.go
+++ b/v_3_3_1/worker_template_test.go
@@ -1,4 +1,4 @@
-package v_3_3_0
+package v_3_3_1
 
 import (
 	"testing"


### PR DESCRIPTION
Updates hyperkube version to v1.10.3 which is latest and has fixes for kubelet we want.

> kubelet: fix hangs in updating Node status after network interruptions/changes between the kubelet and API server (#63492, @liggitt)

Full [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md#changelog-since-v1102).