### PR TITLE
Add parameter to disable Ingress Controller resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ version directory, and then changes are introduced.
 
 ### Removed
 - Removed node-exporter related components (will be managed by chart-operator).
+- Added parameter for disabling Ingress Controller related components.
 
 ## [v3.3.1]
 

--- a/v_3_3_2/master_template.go
+++ b/v_3_3_2/master_template.go
@@ -531,6 +531,8 @@ write_files:
         }
       ]
     }
+
+{{ if not .DisableIngressController -}}
 - path: /srv/default-backend-dep.yml
   owner: root
   permissions: 0644
@@ -717,6 +719,7 @@ write_files:
         targetPort: 443
       selector:
         k8s-app: nginx-ingress-controller
+{{ end -}}
 - path: /srv/kube-proxy-sa.yaml
   owner: root
   permissions: 0644
@@ -1354,9 +1357,11 @@ write_files:
       MANIFESTS="${MANIFESTS} coredns.yaml"
       MANIFESTS="${MANIFESTS} default-backend-dep.yml"
       MANIFESTS="${MANIFESTS} default-backend-svc.yml"
+      {{ if not .DisableIngressController -}}
       MANIFESTS="${MANIFESTS} ingress-controller-cm.yml"
       MANIFESTS="${MANIFESTS} ingress-controller-dep.yml"
       MANIFESTS="${MANIFESTS} ingress-controller-svc.yml"
+      {{ end -}}
 
       for manifest in $MANIFESTS
       do

--- a/v_3_3_2/types.go
+++ b/v_3_3_2/types.go
@@ -15,6 +15,10 @@ type Params struct {
 	// DisableEncryptionAtREST flag when set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool
+	// DisableIngressController flag when set removes all manifests from the
+	// cloud config related to Ingress Controller. This allows us to migrate
+	// providers to chart-operator independently.
+	DisableIngressController bool
 	// Hyperkube allows to pass extra `docker run` and `command` arguments
 	// to hyperkube image commands. This allows to e.g. add cloud provider
 	// extensions.


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Makes Ingress Controller resources configurable. This is so we can migrate providers to chart-operator independently.