### PR TITLE
v_3_3_2: downgrade Kubernetes to 1.10.2 and freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ version directory, and then changes are introduced.
 ## [v3.3.2]
 
 ### Changed
-- Updated hyperkube to version 1.10.2 due to regression on 1.10.3 with configmaps.
+- Updated hyperkube to version 1.10.2 due to regression in 1.10.3 with configmaps.
 
 ### Removed
 - Removed node-exporter related components (will be managed by chart-operator).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ The latest version is considered WIP and it is a subject of change. All other
 versions are frozen. To freeze current version all files are copied to a new
 version directory, and then changes are introduced.
 
-## [v3.3.2] WIP
+## [v3.3.2]
 
 ### Changed
+- Updated hyperkube to version 1.10.2 due to regression on 1.10.3 with configmaps.
 
 ### Removed
 - Removed node-exporter related components (will be managed by chart-operator).

--- a/v_3_3_2/master_template.go
+++ b/v_3_3_2/master_template.go
@@ -1528,7 +1528,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-api-server
-        image: quay.io/giantswarm/hyperkube:v1.10.3
+        image: quay.io/giantswarm/hyperkube:v1.10.2
         env:
         - name: HOST_IP
           valueFrom:

--- a/v_3_3_2/master_template.go
+++ b/v_3_3_2/master_template.go
@@ -763,7 +763,7 @@ write_files:
           serviceAccountName: kube-proxy
           containers:
             - name: kube-proxy
-              image: quay.io/giantswarm/hyperkube:v1.10.3
+              image: quay.io/giantswarm/hyperkube:v1.10.2
               command:
               - /hyperkube
               - proxy
@@ -1650,7 +1650,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-controller-manager
-        image: quay.io/giantswarm/hyperkube:v1.10.3
+        image: quay.io/giantswarm/hyperkube:v1.10.2
         command:
         - /hyperkube
         - controller-manager
@@ -1723,7 +1723,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-scheduler
-        image: quay.io/giantswarm/hyperkube:v1.10.3
+        image: quay.io/giantswarm/hyperkube:v1.10.2
         command:
         - /hyperkube
         - scheduler
@@ -2011,7 +2011,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.3"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_3_2/worker_template.go
+++ b/v_3_3_2/worker_template.go
@@ -248,7 +248,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.3"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/3332

Downgrades K8s to 1.10.2 due to a regression with config maps. Also freezes v_3_3_2 so it can be used in AWS release 4.2.0.