### PR TITLE
v_3_3_3: Update hyperkube to 1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ version directory, and then changes are introduced.
 ## [v3.3.3] WIP
 
 ### Changed
-
+- Updated hyperkube to version 1.10.4.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The latest version is considered WIP and it is a subject of change. All other
 versions are frozen. To freeze current version all files are copied to a new
 version directory, and then changes are introduced.
 
-## [v3.3.3] WIP
+## [v3.3.3]
 
 ### Changed
 

--- a/v_3_3_3/master_template.go
+++ b/v_3_3_3/master_template.go
@@ -763,7 +763,7 @@ write_files:
           serviceAccountName: kube-proxy
           containers:
             - name: kube-proxy
-              image: quay.io/giantswarm/hyperkube:v1.10.2
+              image: quay.io/giantswarm/hyperkube:v1.10.4
               command:
               - /hyperkube
               - proxy
@@ -1528,7 +1528,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-api-server
-        image: quay.io/giantswarm/hyperkube:v1.10.2
+        image: quay.io/giantswarm/hyperkube:v1.10.4
         env:
         - name: HOST_IP
           valueFrom:
@@ -1650,7 +1650,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-controller-manager
-        image: quay.io/giantswarm/hyperkube:v1.10.2
+        image: quay.io/giantswarm/hyperkube:v1.10.4
         command:
         - /hyperkube
         - controller-manager
@@ -1723,7 +1723,7 @@ write_files:
       priorityClassName: core-pods
       containers:
       - name: k8s-scheduler
-        image: quay.io/giantswarm/hyperkube:v1.10.2
+        image: quay.io/giantswarm/hyperkube:v1.10.4
         command:
         - /hyperkube
         - scheduler
@@ -2011,7 +2011,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.4"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_3_3/worker_template.go
+++ b/v_3_3_3/worker_template.go
@@ -248,7 +248,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.2"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.10.4"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/3332

K8s 1.10.4 was released yesterday and has the configmap fix. Tested on gauss including verifying the configmap fix that was a regression in 1.10.3.

See https://github.com/giantswarm/giantswarm/issues/3332