### PR TITLE
Add parameter for disabling ingress controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ version directory, and then changes are introduced.
 ## [v3.3.4] WIP
 
 ### Changed
+- Added parameter for disabling Ingress Controller related components.
 
 ### Removed
 

--- a/v_3_3_4/master_template.go
+++ b/v_3_3_4/master_template.go
@@ -531,6 +531,7 @@ write_files:
         }
       ]
     }
+{{ if not .DisableIngressController -}}    
 - path: /srv/default-backend-dep.yml
   owner: root
   permissions: 0644
@@ -718,6 +719,7 @@ write_files:
         targetPort: 443
       selector:
         k8s-app: nginx-ingress-controller
+{{ end -}}
 - path: /srv/kube-proxy-sa.yaml
   owner: root
   permissions: 0644
@@ -909,6 +911,7 @@ write_files:
       kind: ClusterRole
       name: calico-node
       apiGroup: rbac.authorization.k8s.io
+    {{ if not .DisableIngressController -}}
     ---
     ## IC
     kind: ClusterRoleBinding
@@ -937,6 +940,7 @@ write_files:
       kind: Role
       name: nginx-ingress-role
       apiGroup: rbac.authorization.k8s.io
+    {{ end -}}
 - path: /srv/rbac_roles.yaml
   owner: root
   permissions: 0644
@@ -972,6 +976,7 @@ write_files:
           - nodes
         verbs:
           - get
+    {{ if not .DisableIngressController -}}
     ---
     ## IC
     apiVersion: v1
@@ -1075,6 +1080,7 @@ write_files:
           - get
           - create
           - update
+    {{ end -}}
 - path: /srv/psp_policies.yaml
   owner: root
   permissions: 0644
@@ -1353,11 +1359,13 @@ write_files:
       MANIFESTS="${MANIFESTS} kube-proxy-sa.yaml"
       MANIFESTS="${MANIFESTS} kube-proxy-ds.yaml"
       MANIFESTS="${MANIFESTS} coredns.yaml"
+      {{ if not .DisableIngressController -}}
       MANIFESTS="${MANIFESTS} default-backend-dep.yml"
       MANIFESTS="${MANIFESTS} default-backend-svc.yml"
       MANIFESTS="${MANIFESTS} ingress-controller-cm.yml"
       MANIFESTS="${MANIFESTS} ingress-controller-dep.yml"
       MANIFESTS="${MANIFESTS} ingress-controller-svc.yml"
+      {{ end -}}
 
       for manifest in $MANIFESTS
       do

--- a/v_3_3_4/master_template.go
+++ b/v_3_3_4/master_template.go
@@ -911,7 +911,7 @@ write_files:
       kind: ClusterRole
       name: calico-node
       apiGroup: rbac.authorization.k8s.io
-    {{ if not .DisableIngressController -}}
+{{ if not .DisableIngressController -}}
     ---
     ## IC
     kind: ClusterRoleBinding
@@ -940,7 +940,7 @@ write_files:
       kind: Role
       name: nginx-ingress-role
       apiGroup: rbac.authorization.k8s.io
-    {{ end -}}
+{{ end -}}
 - path: /srv/rbac_roles.yaml
   owner: root
   permissions: 0644
@@ -976,7 +976,7 @@ write_files:
           - nodes
         verbs:
           - get
-    {{ if not .DisableIngressController -}}
+{{ if not .DisableIngressController -}}
     ---
     ## IC
     apiVersion: v1
@@ -1080,7 +1080,7 @@ write_files:
           - get
           - create
           - update
-    {{ end -}}
+{{ end -}}
 - path: /srv/psp_policies.yaml
   owner: root
   permissions: 0644

--- a/v_3_3_4/master_template.go
+++ b/v_3_3_4/master_template.go
@@ -1289,7 +1289,7 @@ write_files:
               /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
-              echo "failed to apply /src/$manifest, retrying in 5 sec"
+              echo "failed to apply /srv/$manifest, retrying in 5 sec"
               sleep 5s
           done
       done
@@ -1298,7 +1298,7 @@ write_files:
           /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/priority_classes.yaml
           [ "$?" -ne "0" ]
       do
-          echo "failed to apply /src/priority_classes.yaml, retrying in 5 sec"
+          echo "failed to apply /srv/priority_classes.yaml, retrying in 5 sec"
           sleep 5s
       done
 
@@ -1318,7 +1318,7 @@ write_files:
               /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
               [ "$?" -ne "0" ]
           do
-              echo "failed to apply /src/$manifest, retrying in 5 sec"
+              echo "failed to apply /srv/$manifest, retrying in 5 sec"
               sleep 5s
           done
       done

--- a/v_3_3_4/types.go
+++ b/v_3_3_4/types.go
@@ -15,6 +15,10 @@ type Params struct {
 	// DisableEncryptionAtREST flag when set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool
+	// DisableIngressController flag when set removes all manifests from the
+	// cloud config related to Ingress Controller. This allows us to migrate
+	// providers to chart-operator independently.
+	DisableIngressController bool
 	// Hyperkube allows to pass extra `docker run` and `command` arguments
 	// to hyperkube image commands. This allows to e.g. add cloud provider
 	// extensions.

--- a/v_3_3_4/types.go
+++ b/v_3_3_4/types.go
@@ -9,13 +9,13 @@ type Params struct {
 	// etcd data.
 	APIServerEncryptionKey string
 	Cluster                v1alpha1.Cluster
-	// DisableCalico flag when set removes all calico related Kubernetes
+	// DisableCalico flag. When set removes all calico related Kubernetes
 	// manifests from the cloud config together with their initialization.
 	DisableCalico bool
-	// DisableEncryptionAtREST flag when set removes all manifests from the cloud
+	// DisableEncryptionAtREST flag. When set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool
-	// DisableIngressController flag when set removes all manifests from the
+	// DisableIngressController flag. When set removes all manifests from the
 	// cloud config related to Ingress Controller. This allows us to migrate
 	// providers to chart-operator independently.
 	DisableIngressController bool


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Allows disabling of Ingress Controller. This is so we can migrate it to chart-operator on Azure first.