### PR TITLE
increase kubelet start timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ version directory, and then changes are introduced.
 
 ### Changed
 - Added parameter for disabling Ingress Controller related components.
+- Increased start timeout for k8s-kubelet.service.
 
 ### Removed
 

--- a/v_3_3_4/master_template.go
+++ b/v_3_3_4/master_template.go
@@ -2018,6 +2018,7 @@ coreos:
       StartLimitIntervalSec=0
 
       [Service]
+      TimeoutStartSec=240
       Restart=always
       RestartSec=0
       TimeoutStopSec=10

--- a/v_3_3_4/worker_template.go
+++ b/v_3_3_4/worker_template.go
@@ -246,6 +246,7 @@ coreos:
       StartLimitIntervalSec=0
 
       [Service]
+      TimeoutStartSec=240
       Restart=always
       RestartSec=0
       TimeoutStopSec=10


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/3386


Pulling hyperkube image for kubelet can take longer, and if it hits timeout systemd will terminate it and the process starts again so its take much more time to spin up.