### PR TITLE
v_3_3_4: Update VerbatimSections to return an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ version directory, and then changes are introduced.
 ### Changed
 - Added parameter for disabling Ingress Controller related components.
 - Increased start timeout for k8s-kubelet.service.
+- Updated VerbatimSections method to return an error.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ version directory, and then changes are introduced.
 ### Changed
 - Added parameter for disabling Ingress Controller related components.
 - Increased start timeout for k8s-kubelet.service.
-- Updated VerbatimSections method to return an error.
+- Updated VerbatimSections to return an error.
 
 ### Removed
 

--- a/v_3_3_4/common_template_test.go
+++ b/v_3_3_4/common_template_test.go
@@ -6,6 +6,6 @@ func (nopWriter) Write(b []byte) (int, error) { return len(b), nil }
 
 type nopExtension struct{}
 
-func (nopExtension) Files() ([]FileAsset, error)         { return nil, nil }
-func (nopExtension) Units() ([]UnitAsset, error)         { return nil, nil }
-func (nopExtension) VerbatimSections() []VerbatimSection { return nil }
+func (nopExtension) Files() ([]FileAsset, error)                  { return nil, nil }
+func (nopExtension) Units() ([]UnitAsset, error)                  { return nil, nil }
+func (nopExtension) VerbatimSections() ([]VerbatimSection, error) { return nil, nil }

--- a/v_3_3_4/types.go
+++ b/v_3_3_4/types.go
@@ -111,5 +111,5 @@ type VerbatimSection struct {
 type Extension interface {
 	Files() ([]FileAsset, error)
 	Units() ([]UnitAsset, error)
-	VerbatimSections() []VerbatimSection
+	VerbatimSections() ([]VerbatimSection, error)
 }

--- a/v_3_4_0/common_template_test.go
+++ b/v_3_4_0/common_template_test.go
@@ -6,6 +6,6 @@ func (nopWriter) Write(b []byte) (int, error) { return len(b), nil }
 
 type nopExtension struct{}
 
-func (nopExtension) Files() ([]FileAsset, error)         { return nil, nil }
-func (nopExtension) Units() ([]UnitAsset, error)         { return nil, nil }
-func (nopExtension) VerbatimSections() []VerbatimSection { return nil }
+func (nopExtension) Files() ([]FileAsset, error)                  { return nil, nil }
+func (nopExtension) Units() ([]UnitAsset, error)                  { return nil, nil }
+func (nopExtension) VerbatimSections() ([]VerbatimSection, error) { return nil, nil }

--- a/v_3_4_0/types.go
+++ b/v_3_4_0/types.go
@@ -111,5 +111,5 @@ type VerbatimSection struct {
 type Extension interface {
 	Files() ([]FileAsset, error)
 	Units() ([]UnitAsset, error)
-	VerbatimSections() []VerbatimSection
+	VerbatimSections() ([]VerbatimSection, error)
 }


### PR DESCRIPTION
For China I need to disable encryption for the K8s storage class we create. As it uses KMS which is not yet available in AWS China regions.

Since I need to render a template I've updated VerbatimSections to return an error.

@corest you added v_3_4_0. Should I be using this for dev? 