### PR TITLE
Use retagged etcd image

### DIFF
--- a/v_3_4_0/master_template.go
+++ b/v_3_4_0/master_template.go
@@ -1963,7 +1963,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE={{ .RegistryDomain }}/coreos/etcd:v3.3.3
+      Environment=IMAGE={{ .RegistryDomain }}/giantswarm/etcd:v3.3.3
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
@@ -2012,7 +2012,7 @@ coreos:
       [Service]
       Type=oneshot
       EnvironmentFile=/etc/network-environment
-      Environment=IMAGE={{ .RegistryDomain }}/coreos/etcd:v3.3.3
+      Environment=IMAGE={{ .RegistryDomain }}/giantswarm/etcd:v3.3.3
       Environment=NAME=%p.service
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME


### PR DESCRIPTION
We are using original coreos/etcd instead of our retagged image. This change will allow us to use etcd on aliyun.