### PR TITLE
Use static worker count for nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ version directory, and then changes are introduced.
 - Added RBAC rules for node-operator.
 - Enabled monitoring for ingress controller metrics.
 - Parameterize image registry domain.
+- Set "worker-processes" to 4 for nginx-ingress-controller.
 
 ### Changed
 - Add memory eviction thresholds for kubelet in order to preserve node in case of heavy load.

--- a/v_3_4_0/master_template.go
+++ b/v_3_4_0/master_template.go
@@ -605,6 +605,7 @@ write_files:
       server-name-hash-bucket-size: "1024"
       server-name-hash-max-size: "1024"
       server-tokens: "false"
+      worker-processes: "4"
 - path: /srv/ingress-controller-dep.yml
   owner: root
   permissions: 0644


### PR DESCRIPTION
By default controller starts worker number equal to number of cores. Every worker consumes 45MB memory in stand-by, this causes OOM kills (for default limit 700MB) if core number >=16 (Big VMs).

Fixes: https://github.com/giantswarm/giantswarm/issues/3536