### PR TITLE
add rbac rules for prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ version directory, and then changes are introduced.
 ### Added
 - Added SSO public key into ssh trusted CA.
 - Added RBAC rules for node-operator.
+- Added RBAC rules for prometheus.
 - Enabled monitoring for ingress controller metrics.
 - Parameterize image registry domain.
 

--- a/v_3_4_0/master_template.go
+++ b/v_3_4_0/master_template.go
@@ -908,6 +908,20 @@ write_files:
       name: node-operator
       apiGroup: rbac.authorization.k8s.io
     ---
+    ## prometheus-external is prometheus from host cluster
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: prometheus-external
+    subjects:
+    - kind: User
+      name: prometheus.{{.BaseDomain}}
+      apiGroup: rbac.authorization.k8s.io
+    roleRef:
+      kind: ClusterRole
+      name: prometheus-external
+      apiGroup: rbac.authorization.k8s.io
+    ---
     ## Calico
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -980,6 +994,28 @@ write_files:
     - apiGroups: [""]
       resources: ["pods"]
       verbs: ["list", "delete"]
+    ---
+    ## prometheus-external
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: prometheus-external
+    rules:
+    - apiGroups: [""]
+      resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+      verbs: ["get", "list", "watch"]
+    - apiGroups:
+      - extensions
+      resources:
+      - ingresses
+      verbs: ["get", "list", "watch"]
+    - nonResourceURLs: ["/metrics"]
+      verbs: ["get"]
     ---
     ## Calico
     kind: ClusterRole


### PR DESCRIPTION
add RBAC rules for the host cluster prometheus ( will be needed when we switch to specific certs per service, now we mostly use `api.xxx` certs but we will use `prometheus.xxx`)

RBAC rules copied from https://github.com/prometheus/prometheus/blob/master/documentation/examples/rbac-setup.yml