### PR TITLE
Disable HSTS headers for Ingress Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ version directory, and then changes are introduced.
 
 ### Changed
 
+- Disabled HSTS headers in nginx-ingress-controller.
 
 ### Removed
 

--- a/v_3_5_0/master_template.go
+++ b/v_3_5_0/master_template.go
@@ -606,6 +606,9 @@ write_files:
       server-name-hash-max-size: "1024"
       server-tokens: "false"
       worker-processes: "4"
+      # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
+      # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
+      hsts: "false"
 - path: /srv/ingress-controller-dep.yml
   owner: root
   permissions: 0644


### PR DESCRIPTION
See https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/23 from @marians. I'd like to keep the chart and the manifests here in sync until the AWS and KVM migration is complete.