### PR TITLE
Upgrade calico to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ version directory, and then changes are introduced.
 
 ### Changed
 - Updated Kubernetes (hyperkube) to version 1.11.1.
+- Updated Calico to version 3.2.0.
 
 ### Removed
 

--- a/v_3_6_0/master_template.go
+++ b/v_3_6_0/master_template.go
@@ -48,7 +48,7 @@ write_files:
       calico_backend: "bird"
 
       # Configure the MTU to use
-      veth_mtu: "1440"
+      veth_mtu: "{{.Cluster.Calico.MTU}}"
 
       # The CNI network configuration to install on each node.  The special
       # values in this config will be automatically populated.

--- a/v_3_6_0/master_template.go
+++ b/v_3_6_0/master_template.go
@@ -229,7 +229,6 @@ write_files:
               resources:
                 requests:
                   cpu: 250m
-                  memory: 100Mi
               livenessProbe:
                 httpGet:
                   path: /liveness

--- a/v_3_6_0/master_template.go
+++ b/v_3_6_0/master_template.go
@@ -408,6 +408,79 @@ write_files:
     metadata:
       name: calico-kube-controllers
       namespace: kube-system
+    ---
+
+    # Calico Version v3.2.0
+    # https://docs.projectcalico.org/v3.2/releases#v3.2.0
+
+    ---
+
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-kube-controllers
+    rules:
+      - apiGroups:
+        - ""
+        - extensions
+        resources:
+          - pods
+          - namespaces
+          - networkpolicies
+          - nodes
+          - serviceaccounts
+        verbs:
+          - watch
+          - list
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+          - networkpolicies
+        verbs:
+          - watch
+          - list
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-kube-controllers
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+
+    ---
+
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-node
+    rules:
+      - apiGroups: [""]
+        resources:
+          - pods
+          - nodes
+        verbs:
+          - get
+
+    ---
+
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
 {{ end -}}
 - path: /srv/coredns.yaml
   owner: root
@@ -977,33 +1050,6 @@ write_files:
       kind: ClusterRole
       name: prometheus-external
       apiGroup: rbac.authorization.k8s.io
-    ---
-    ## Calico
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: calico-kube-controllers
-    subjects:
-    - kind: ServiceAccount
-      name: calico-kube-controllers
-      namespace: kube-system
-    roleRef:
-      kind: ClusterRole
-      name: calico-kube-controllers
-      apiGroup: rbac.authorization.k8s.io
-    ---
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: calico-node
-    subjects:
-    - kind: ServiceAccount
-      name: calico-node
-      namespace: kube-system
-    roleRef:
-      kind: ClusterRole
-      name: calico-node
-      apiGroup: rbac.authorization.k8s.io
 {{- if not .DisableIngressController }}
     ---
     ## IC
@@ -1072,38 +1118,6 @@ write_files:
       verbs: ["get", "list", "watch"]
     - nonResourceURLs: ["/metrics"]
       verbs: ["get"]
-    ---
-    ## Calico
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
-    rules:
-      - apiGroups:
-        - ""
-        - extensions
-        resources:
-          - pods
-          - namespaces
-          - networkpolicies
-          - nodes
-        verbs:
-          - watch
-          - list
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: calico-node
-      namespace: kube-system
-    rules:
-      - apiGroups: [""]
-        resources:
-          - pods
-          - nodes
-        verbs:
-          - get
 {{- if not .DisableIngressController }}
     ---
     ## IC

--- a/v_3_6_0/master_template.go
+++ b/v_3_6_0/master_template.go
@@ -22,6 +22,9 @@ write_files:
   owner: root
   permissions: 644
   content: |
+    # Extra changes:
+    #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
+    #
     # Calico Version v3.2.0
     # https://docs.projectcalico.org/v3.2/releases#v3.2.0
     # This manifest includes the following component versions:
@@ -65,6 +68,7 @@ write_files:
               "etcd_cert_file": "__ETCD_CERT_FILE__",
               "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
               "mtu": __CNI_MTU__,
+              "nodename_file_optional": true,
               "ipam": {
                   "type": "calico-ipam"
               },

--- a/v_3_6_0/master_template.go
+++ b/v_3_6_0/master_template.go
@@ -18,34 +18,16 @@ write_files:
   content: |
     {{ .SSOPublicKey }}
 {{ if not .DisableCalico -}}
-- path: /srv/calico-kube-controllers-sa.yaml
+- path: /srv/calico-all.yaml
   owner: root
   permissions: 644
   content: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
-- path: /srv/calico-node-sa.yaml
-  owner: root
-  permissions: 644
-  content: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: calico-node
-      namespace: kube-system
-- path: /srv/calico-configmap.yaml
-  owner: root
-  permissions: 644
-  content: |
-    # Calico Version v3.0.5
-    # https://docs.projectcalico.org/v3.0/releases#v3.0.5
+    # Calico Version v3.2.0
+    # https://docs.projectcalico.org/v3.2/releases#v3.2.0
     # This manifest includes the following component versions:
-    #   calico/node:v3.0.5
-    #   calico/cni:v2.0.4
-    #   calico/kube-controllers:v2.0.3
+    #   calico/node:v3.2.0
+    #   calico/cni:v3.2.0
+    #   calico/kube-controllers:v3.2.0
 
     # This ConfigMap is used to configure a self-hosted Calico installation.
     kind: ConfigMap
@@ -57,34 +39,41 @@ write_files:
       # Configure this with the location of your etcd cluster.
       etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }}"
 
+      # If you're using TLS enabled etcd uncomment the following.
+      # You must also populate the Secret below with these files.
+      etcd_ca: "/calico-secrets/client-ca.pem"
+      etcd_cert: "/calico-secrets/client-crt.pem"
+      etcd_key: "/calico-secrets/client-key.pem"
       # Configure the Calico backend to use.
       calico_backend: "bird"
 
-      # The CNI network configuration to install on each node.
+      # Configure the MTU to use
+      veth_mtu: "1440"
+
+      # The CNI network configuration to install on each node.  The special
+      # values in this config will be automatically populated.
       cni_network_config: |-
         {
           "name": "k8s-pod-network",
           "cniVersion": "0.3.0",
           "plugins": [
             {
-                "type": "calico",
-                "etcd_endpoints": "__ETCD_ENDPOINTS__",
-                "etcd_key_file": "__ETCD_KEY_FILE__",
-                "etcd_cert_file": "__ETCD_CERT_FILE__",
-                "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
-                "log_level": "info",
-                "mtu": {{.Cluster.Calico.MTU}},
-                "ipam": {
-                    "type": "calico-ipam"
-                },
-                "policy": {
-                    "type": "k8s",
-                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-                },
-                "kubernetes": {
-                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
-                }
+              "type": "calico",
+              "log_level": "info",
+              "etcd_endpoints": "__ETCD_ENDPOINTS__",
+              "etcd_key_file": "__ETCD_KEY_FILE__",
+              "etcd_cert_file": "__ETCD_CERT_FILE__",
+              "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s"
+              },
+              "kubernetes": {
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
             },
             {
               "type": "portmap",
@@ -94,16 +83,28 @@ write_files:
           ]
         }
 
-      # If you're using TLS enabled etcd uncomment the following.
-      # You must also populate the Secret below with these files.
-      etcd_ca: "/etc/kubernetes/ssl/etcd/client-ca.pem"
-      etcd_cert: "/etc/kubernetes/ssl/etcd/client-crt.pem"
-      etcd_key: "/etc/kubernetes/ssl/etcd/client-key.pem"
+    ---
 
-- path: /srv/calico-ds.yaml
-  owner: root
-  permissions: 644
-  content: |
+
+    # The following contains k8s Secrets for use with a TLS enabled etcd cluster.
+    # For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+    apiVersion: v1
+    kind: Secret
+    type: Opaque
+    metadata:
+      name: calico-etcd-secrets
+      namespace: kube-system
+    data:
+      # Populate the following files with etcd TLS configuration if desired, but leave blank if
+      # not using TLS for etcd.
+      # This self-hosted install expects three files with the following names.  The values
+      # should be base64 encoded strings of the entire contents of each file.
+      # etcd-key: null
+      # etcd-cert: null
+      # etcd-ca: null
+
+    ---
+
     # This manifest installs the calico/node container, as well
     # as the Calico CNI plugins and network config on
     # each master and worker node in a Kubernetes cluster.
@@ -127,15 +128,22 @@ write_files:
           labels:
             k8s-app: calico-node
           annotations:
+            # This, along with the CriticalAddonsOnly toleration below,
+            # marks the pod as a critical add-on, ensuring it gets
+            # priority scheduling and that its resources are reserved
+            # if it ever gets evicted.
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
-          # Tolerations part was taken from calico manifest for kubeadm as we are using same taint for master.
-          tolerations:
-          - key: node-role.kubernetes.io/master
-            operator: Exists
-            effect: NoSchedule
           hostNetwork: true
-          priorityClassName: system-node-critical
+          tolerations:
+            # Make sure calico-node gets scheduled on all nodes.
+            - effect: NoSchedule
+              operator: Exists
+            # Mark the pod as a critical add-on for rescheduling.
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
           serviceAccountName: calico-node
           # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
           # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
@@ -145,7 +153,7 @@ write_files:
             # container programs network policy and routes on each
             # host.
             - name: calico-node
-              image: {{ .RegistryDomain }}/giantswarm/node:v3.0.5
+              image: {{ .RegistryDomain }}/giantswarm/node:v3.2.0
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -153,40 +161,6 @@ write_files:
                     configMapKeyRef:
                       name: calico-config
                       key: etcd_endpoints
-                # Choose the backend to use.
-                - name: CALICO_NETWORKING_BACKEND
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: calico_backend
-                # Cluster type to identify the deployment type
-                - name: CLUSTER_TYPE
-                  value: "k8s,bgp"
-                # Disable file logging so kubectl logs works.
-                - name: CALICO_DISABLE_FILE_LOGGING
-                  value: "true"
-                # Set Felix endpoint to host default action to ACCEPT.
-                - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-                  value: "ACCEPT"
-                # Configure the IP Pool from which Pod IPs will be chosen.
-                - name: CALICO_IPV4POOL_CIDR
-                  value: "{{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}"
-                - name: CALICO_IPV4POOL_IPIP
-                  value: "always"
-                # Set noderef for node controller.
-                - name: CALICO_K8S_NODE_REF
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                # Disable IPv6 on Kubernetes.
-                - name: FELIX_IPV6SUPPORT
-                  value: "false"
-                # Set Felix logging to "info"
-                - name: FELIX_LOGSEVERITYSCREEN
-                  value: "info"
-                # Set MTU for tunnel device used if ipip is enabled
-                - name: FELIX_IPINIPMTU
-                  value: "1440"
                 # Location of the CA certificate for etcd.
                 - name: ETCD_CA_CERT_FILE
                   valueFrom:
@@ -205,9 +179,49 @@ write_files:
                     configMapKeyRef:
                       name: calico-config
                       key: etcd_cert
+                # Set noderef for node controller.
+                - name: CALICO_K8S_NODE_REF
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                # Choose the backend to use.
+                - name: CALICO_NETWORKING_BACKEND
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: calico_backend
+                # Cluster type to identify the deployment type
+                - name: CLUSTER_TYPE
+                  value: "k8s,bgp"
                 # Auto-detect the BGP IP address.
                 - name: IP
-                  value: ""
+                  value: "autodetect"
+                # Enable IPIP
+                - name: CALICO_IPV4POOL_IPIP
+                  value: "Always"
+                # Set MTU for tunnel device used if ipip is enabled
+                - name: FELIX_IPINIPMTU
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: veth_mtu
+                # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+                # chosen from this range. Changing this value after installation will have
+                # no effect. This should fall within --cluster-cidr.
+                - name: CALICO_IPV4POOL_CIDR
+                  value: "{{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}"
+                # Disable file logging so kubectl logs works.
+                - name: CALICO_DISABLE_FILE_LOGGING
+                  value: "true"
+                # Set Felix endpoint to host default action to ACCEPT.
+                - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+                  value: "ACCEPT"
+                # Disable IPv6 on Kubernetes.
+                - name: FELIX_IPV6SUPPORT
+                  value: "false"
+                # Set Felix logging to "info"
+                - name: FELIX_LOGSEVERITYSCREEN
+                  value: "info"
                 - name: FELIX_HEALTHENABLED
                   value: "true"
               securityContext:
@@ -220,13 +234,16 @@ write_files:
                 httpGet:
                   path: /liveness
                   port: 9099
+                  host: localhost
                 periodSeconds: 10
                 initialDelaySeconds: 10
                 failureThreshold: 6
               readinessProbe:
-                httpGet:
-                  path: /readiness
-                  port: 9099
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -bird-ready
+                  - -felix-ready
                 periodSeconds: 10
               volumeMounts:
                 - mountPath: /lib/modules
@@ -235,12 +252,15 @@ write_files:
                 - mountPath: /var/run/calico
                   name: var-run-calico
                   readOnly: false
-                - mountPath: /etc/kubernetes/ssl/etcd
+                - mountPath: /var/lib/calico
+                  name: var-lib-calico
+                  readOnly: false
+                - mountPath: /calico-secrets
                   name: etcd-certs
             # This container installs the Calico CNI binaries
             # and CNI network config file on each node.
             - name: install-cni
-              image: {{ .RegistryDomain }}/giantswarm/cni:v2.0.4
+              image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.0
               command: ["/install-cni.sh"]
               env:
                 # Name of the CNI config file to create.
@@ -258,12 +278,18 @@ write_files:
                     configMapKeyRef:
                       name: calico-config
                       key: cni_network_config
+                # CNI MTU Config variable
+                - name: CNI_MTU
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: veth_mtu
               volumeMounts:
                 - mountPath: /host/opt/cni/bin
                   name: cni-bin-dir
                 - mountPath: /host/etc/cni/net.d
                   name: cni-net-dir
-                - mountPath: /etc/kubernetes/ssl/etcd
+                - mountPath: /calico-secrets
                   name: etcd-certs
           volumes:
             # Used by calico/node.
@@ -273,6 +299,9 @@ write_files:
             - name: var-run-calico
               hostPath:
                 path: /var/run/calico
+            - name: var-lib-calico
+              hostPath:
+                path: /var/lib/calico
             # Used to install CNI.
             - name: cni-bin-dir
               hostPath:
@@ -284,10 +313,16 @@ write_files:
             - name: etcd-certs
               hostPath:
                 path: /etc/kubernetes/ssl/etcd
-- path: /srv/calico-kube-controllers.yaml
-  owner: root
-  permissions: 644
-  content: |
+    ---
+
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+
+    ---
+
     # This manifest deploys the Calico Kubernetes controllers.
     # See https://github.com/projectcalico/kube-controllers
     apiVersion: extensions/v1beta1
@@ -297,6 +332,8 @@ write_files:
       namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       # The controllers can only have a single active instance.
       replicas: 1
@@ -308,22 +345,20 @@ write_files:
           namespace: kube-system
           labels:
             k8s-app: calico-kube-controllers
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
-          # Tolerations part was taken from calico manifest for kubeadm as we are using same taint for master.
-          tolerations:
-          - key: node-role.kubernetes.io/master
-            operator: Exists
-            effect: NoSchedule
           # The controllers must run in the host network namespace so that
           # it isn't governed by policy that would prevent it from working.
           hostNetwork: true
-          priorityClassName: system-cluster-critical
+          tolerations:
+            # Mark the pod as a critical add-on for rescheduling.
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
           serviceAccountName: calico-kube-controllers
           containers:
             - name: calico-kube-controllers
-              image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v2.0.3
+              image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.0
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -352,19 +387,28 @@ write_files:
                 # Choose which controllers to run.
                 - name: ENABLED_CONTROLLERS
                   value: policy,profile,workloadendpoint,node
-              resources:
-                requests:
-                  cpu: 30m
-                  memory: 90Mi
               volumeMounts:
                 # Mount in the etcd TLS secrets.
-                - mountPath: /etc/kubernetes/ssl/etcd
+                - mountPath: /calico-secrets
                   name: etcd-certs
+              readinessProbe:
+                exec:
+                  command:
+                  - /usr/bin/check-status
+                  - -r
           volumes:
             # Mount in the etcd TLS secrets.
             - name: etcd-certs
               hostPath:
                 path: /etc/kubernetes/ssl/etcd
+
+    ---
+
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
 {{ end -}}
 - path: /srv/coredns.yaml
   owner: root
@@ -1346,23 +1390,15 @@ write_files:
 
       {{ if not .DisableCalico -}}
 
-      # apply calico CNI
-      CALICO_FILES=""
-      CALICO_FILES="${CALICO_FILES} calico-configmap.yaml"
-      CALICO_FILES="${CALICO_FILES} calico-node-sa.yaml"
-      CALICO_FILES="${CALICO_FILES} calico-kube-controllers-sa.yaml"
-      CALICO_FILES="${CALICO_FILES} calico-ds.yaml"
-      CALICO_FILES="${CALICO_FILES} calico-kube-controllers.yaml"
+      # apply calico
+      CALICO_FILE="calico-all.yaml"
 
-      for manifest in $CALICO_FILES
+      while
+          /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$CALICO_FILE
+          [ "$?" -ne "0" ]
       do
-          while
-              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
-              [ "$?" -ne "0" ]
-          do
-              echo "failed to apply /srv/$manifest, retrying in 5 sec"
-              sleep 5s
-          done
+          echo "failed to apply /srv/$manifest, retrying in 5 sec"
+          sleep 5s
       done
 
       # wait for healthy calico - we check for pods - desired vs ready
@@ -2153,6 +2189,7 @@ coreos:
       -v /run/docker.sock:/run/docker.sock:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
+      -v /var/lib/calico/:/var/lib/calico \
       -v /var/lib/docker/:/var/lib/docker:rw,rshared \
       -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \

--- a/v_3_6_0/worker_template.go
+++ b/v_3_6_0/worker_template.go
@@ -330,6 +330,7 @@ coreos:
       -v /run/docker.sock:/run/docker.sock:rw \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
+      -v /var/lib/calico/:/var/lib/calico \
       -v /var/lib/docker/:/var/lib/docker:rw,rshared \
       -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \


### PR DESCRIPTION
Part of: https://github.com/giantswarm/giantswarm/issues/3922

also move to single manifest like we do in "control plane" cluster. this allows to copy-paste official upstream manifests.