### PR TITLE
fix coredns manifest removal

### DIFF
--- a/v_3_6_0/master_template.go
+++ b/v_3_6_0/master_template.go
@@ -1455,7 +1455,7 @@ write_files:
       {{ end -}}
       MANIFESTS="${MANIFESTS} kube-proxy-sa.yaml"
       MANIFESTS="${MANIFESTS} kube-proxy-ds.yaml"
-      {{- if not .DisableCoreDNS }}
+      {{ if not .DisableCoreDNS }}
       MANIFESTS="${MANIFESTS} coredns.yaml"
       {{ end -}}
       {{ if not .DisableIngressController -}}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/4242

The extra dash was causing:
```
Sep 24 09:22:38 ip-10-1-6-27.eu-central-1.compute.internal k8s-addons[2131]: error: the path "/srv/kube-proxy-ds.yamlMANIFESTS=" does not exist
Sep 24 09:22:38 ip-10-1-6-27.eu-central-1.compute.internal k8s-addons[2131]: failed to apply /srv/kube-proxy-ds.yamlMANIFESTS=, retrying in 5 sec
```