### PR TITLE
Replace cloudinit encoding with ignition compression

### DIFF
--- a/v_4_0_0/master_template.go
+++ b/v_4_0_0/master_template.go
@@ -525,6 +525,9 @@ storage:
       mode: {{printf "%#o" .Metadata.Permissions}}
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{ .Content }}"
+        {{ if .Metadata.Compression }}
+        compression: gzip
+        {{end}}
     {{ end -}}
 
 {{ range .Extension.VerbatimSections }}

--- a/v_4_0_0/types.go
+++ b/v_4_0_0/types.go
@@ -92,7 +92,7 @@ type FileMetadata struct {
 	AssetContent string
 	Path         string
 	Owner        Owner
-	Encoding     string
+	Compression  bool
 	Permissions  int
 }
 

--- a/v_4_0_0/worker_template.go
+++ b/v_4_0_0/worker_template.go
@@ -261,6 +261,9 @@ storage:
       mode: {{printf "%#o" .Metadata.Permissions}}
       contents:
         source: "data:text/plain;charset=utf-8,{{ .Content }}"
+        {{ if .Metadata.Compression }}
+        compression: gzip
+        {{end}}
     {{ end -}}
 
 {{ range .Extension.VerbatimSections }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2816

cloudinit used schema "base64_gzip" for `encoding` field.
ignition uses `base64` in data schema uri and has only `gzip` for compression. So, operators, which are rendering ignition, will use boolean value to enable compression