### PR TITLE
Add resource limits for calico and update to 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ version directory, and then changes are introduced.
 ## [v3.6.2]
 
 ### Changed
+- Updated Calico to 3.2.2 and added resource limits.
 
 ## [v3.6.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ version directory, and then changes are introduced.
 - Switched from cloudinit to ignition.
 - Enable admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
 - Use patched GiantSwarm build of Kubernetes (`hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm`).
+- Updated Calico to 3.2.2 and added resource limits.
 
 ## [v3.6.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ version directory, and then changes are introduced.
 - Switched from cloudinit to ignition.
 - Enable admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
 - Use patched GiantSwarm build of Kubernetes (`hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm`).
-- Updated Calico to 3.2.2 and added resource limits.
+- Updated Calico to 3.2.3
+- Updated Calico manifest with resource limits.
 
 ## [v3.6.2]
 
 ### Changed
-- Updated Calico to 3.2.2 and added resource limits.
+- Updated Calico to 3.2.3
+- Updated Calico manifest with resource limits.
 
 ## [v3.6.1]
 

--- a/v_3_6_2/master_template.go
+++ b/v_3_6_2/master_template.go
@@ -26,12 +26,12 @@ write_files:
     #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
     #  - added resource limits
     #
-    # Calico Version v3.2.2
-    # https://docs.projectcalico.org/v3.2/releases#v3.2.2
+    # Calico Version v3.2.3
+    # https://docs.projectcalico.org/v3.2/releases#v3.2.3
     # This manifest includes the following component versions:
-    #   calico/node:v3.2.2
-    #   calico/cni:v3.2.2
-    #   calico/kube-controllers:v3.2.2
+    #   calico/node:v3.2.3
+    #   calico/cni:v3.2.3
+    #   calico/kube-controllers:v3.2.3
 
     # This ConfigMap is used to configure a self-hosted Calico installation.
     kind: ConfigMap
@@ -160,7 +160,7 @@ write_files:
             # container programs network policy and routes on each
             # host.
             - name: calico-node
-              image: {{ .RegistryDomain }}/giantswarm/node:v3.2.2
+              image: {{ .RegistryDomain }}/giantswarm/node:v3.2.3
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -270,7 +270,7 @@ write_files:
             # This container installs the Calico CNI binaries
             # and CNI network config file on each node.
             - name: install-cni
-              image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.2
+              image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.3
               command: ["/install-cni.sh"]
               env:
                 # Name of the CNI config file to create.
@@ -368,7 +368,7 @@ write_files:
           serviceAccountName: calico-kube-controllers
           containers:
             - name: calico-kube-controllers
-              image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.2
+              image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.3
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -428,8 +428,8 @@ write_files:
       namespace: kube-system
     ---
 
-    # Calico Version v3.2.2
-    # https://docs.projectcalico.org/v3.2/releases#v3.2.2
+    # Calico Version v3.2.3
+    # https://docs.projectcalico.org/v3.2/releases#v3.2.3
 
     ---
 

--- a/v_3_6_2/master_template.go
+++ b/v_3_6_2/master_template.go
@@ -25,12 +25,12 @@ write_files:
     # Extra changes:
     #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
     #
-    # Calico Version v3.2.0
-    # https://docs.projectcalico.org/v3.2/releases#v3.2.0
+    # Calico Version v3.2.2
+    # https://docs.projectcalico.org/v3.2/releases#v3.2.2
     # This manifest includes the following component versions:
-    #   calico/node:v3.2.0
-    #   calico/cni:v3.2.0
-    #   calico/kube-controllers:v3.2.0
+    #   calico/node:v3.2.2
+    #   calico/cni:v3.2.2
+    #   calico/kube-controllers:v3.2.2
 
     # This ConfigMap is used to configure a self-hosted Calico installation.
     kind: ConfigMap
@@ -138,6 +138,8 @@ write_files:
             # if it ever gets evicted.
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
+          nodeSelector:
+            beta.kubernetes.io/os: linux
           hostNetwork: true
           tolerations:
             # Make sure calico-node gets scheduled on all nodes.
@@ -157,7 +159,7 @@ write_files:
             # container programs network policy and routes on each
             # host.
             - name: calico-node
-              image: {{ .RegistryDomain }}/giantswarm/node:v3.2.0
+              image: {{ .RegistryDomain }}/giantswarm/node:v3.2.2
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -233,6 +235,10 @@ write_files:
               resources:
                 requests:
                   cpu: 250m
+                  memory: 150Mi
+                limits:
+                  cpu: 250m
+                  memory: 150Mi
               livenessProbe:
                 httpGet:
                   path: /liveness
@@ -263,7 +269,7 @@ write_files:
             # This container installs the Calico CNI binaries
             # and CNI network config file on each node.
             - name: install-cni
-              image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.0
+              image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.2
               command: ["/install-cni.sh"]
               env:
                 # Name of the CNI config file to create.
@@ -361,7 +367,7 @@ write_files:
           serviceAccountName: calico-kube-controllers
           containers:
             - name: calico-kube-controllers
-              image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.0
+              image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.2
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -394,6 +400,13 @@ write_files:
                 # Mount in the etcd TLS secrets.
                 - mountPath: /calico-secrets
                   name: etcd-certs
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 100Mi
+                limits:
+                  cpu: 250m
+                  memory: 100Mi
               readinessProbe:
                 exec:
                   command:
@@ -414,8 +427,8 @@ write_files:
       namespace: kube-system
     ---
 
-    # Calico Version v3.2.0
-    # https://docs.projectcalico.org/v3.2/releases#v3.2.0
+    # Calico Version v3.2.2
+    # https://docs.projectcalico.org/v3.2/releases#v3.2.2
 
     ---
 

--- a/v_3_6_2/master_template.go
+++ b/v_3_6_2/master_template.go
@@ -24,6 +24,7 @@ write_files:
   content: |
     # Extra changes:
     #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
+    #  - added resource limits
     #
     # Calico Version v3.2.2
     # https://docs.projectcalico.org/v3.2/releases#v3.2.2

--- a/v_4_0_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_0_0/files/k8s-resource/calico-all.yaml
@@ -1,12 +1,13 @@
 # Extra changes:
 #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
+#  - added resource limits
 #
-# Calico Version v3.2.0
-# https://docs.projectcalico.org/v3.2/releases#v3.2.0
+# Calico Version v3.2.2
+# https://docs.projectcalico.org/v3.2/releases#v3.2.2
 # This manifest includes the following component versions:
-#   calico/node:v3.2.0
-#   calico/cni:v3.2.0
-#   calico/kube-controllers:v3.2.0
+#   calico/node:v3.2.2
+#   calico/cni:v3.2.2
+#   calico/kube-controllers:v3.2.2
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -109,6 +110,8 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure calico-node gets scheduled on all nodes.
@@ -128,7 +131,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .RegistryDomain }}/giantswarm/node:v3.2.0
+          image: {{ .RegistryDomain }}/giantswarm/node:v3.2.2
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -204,6 +207,10 @@ spec:
           resources:
             requests:
               cpu: 250m
+              memory: 150Mi
+            limits:
+              cpu: 250m
+              memory: 150Mi
           livenessProbe:
             httpGet:
               path: /liveness
@@ -234,7 +241,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.0
+          image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.2
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -329,7 +336,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.0
+          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.2
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -362,6 +369,13 @@ spec:
             # Mount in the etcd TLS secrets.
             - mountPath: /calico-secrets
               name: etcd-certs
+          resources:
+            requests:
+              cpu: 250m
+              memory: 100Mi
+            limits:
+              cpu: 250m
+              memory: 100Mi
           readinessProbe:
             exec:
               command:
@@ -380,8 +394,8 @@ metadata:
   namespace: kube-system
 ---
 
-# Calico Version v3.2.0
-# https://docs.projectcalico.org/v3.2/releases#v3.2.0
+# Calico Version v3.2.2
+# https://docs.projectcalico.org/v3.2/releases#v3.2.2
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/v_4_0_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_0_0/files/k8s-resource/calico-all.yaml
@@ -2,12 +2,12 @@
 #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
 #  - added resource limits
 #
-# Calico Version v3.2.2
-# https://docs.projectcalico.org/v3.2/releases#v3.2.2
+# Calico Version v3.2.3
+# https://docs.projectcalico.org/v3.2/releases#v3.2.3
 # This manifest includes the following component versions:
-#   calico/node:v3.2.2
-#   calico/cni:v3.2.2
-#   calico/kube-controllers:v3.2.2
+#   calico/node:v3.2.3
+#   calico/cni:v3.2.3
+#   calico/kube-controllers:v3.2.3
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -131,7 +131,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .RegistryDomain }}/giantswarm/node:v3.2.2
+          image: {{ .RegistryDomain }}/giantswarm/node:v3.2.3
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -241,7 +241,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.2
+          image: {{ .RegistryDomain }}/giantswarm/cni:v3.2.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -336,7 +336,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.2
+          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.2.3
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -394,8 +394,8 @@ metadata:
   namespace: kube-system
 ---
 
-# Calico Version v3.2.2
-# https://docs.projectcalico.org/v3.2/releases#v3.2.2
+# Calico Version v3.2.3
+# https://docs.projectcalico.org/v3.2/releases#v3.2.3
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Part of: https://github.com/giantswarm/giantswarm/issues/4159