### PR TITLE
Bring back lost change in 4.0.0 and backport to 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ version directory, and then changes are introduced.
 
 ### Changed
 - Switched from cloudinit to ignition.
-- Enable admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
+- Enabled admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
 - Use patched GiantSwarm build of Kubernetes (`hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm`).
 - Updated Calico to 3.2.3
 - Updated Calico manifest with resource limits.
@@ -23,6 +23,7 @@ version directory, and then changes are introduced.
 ### Changed
 - Updated Calico to 3.2.3
 - Updated Calico manifest with resource limits.
+- Enabled admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
 
 ## [v3.6.1]
 

--- a/v_3_6_2/master_template.go
+++ b/v_3_6_2/master_template.go
@@ -1730,7 +1730,7 @@ write_files:
         - --repair-malformed-updates=false
         - --service-account-lookup=true
         - --authorization-mode=RBAC
-        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority
+        - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
         - --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}}
         - --etcd-servers=https://127.0.0.1:2379

--- a/v_4_0_0/files/manifests/k8s-api-server.yaml
+++ b/v_4_0_0/files/manifests/k8s-api-server.yaml
@@ -35,7 +35,7 @@ spec:
     - --repair-malformed-updates=false
     - --service-account-lookup=true
     - --authorization-mode=RBAC
-    - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority
+    - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
     - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
     - --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}}
     - --etcd-servers=https://127.0.0.1:2379


### PR DESCRIPTION
in 4.0.0 change https://github.com/giantswarm/k8scloudconfig/pull/420 was lost also backport to 3.6.2 (which will be current WIP in operators)