### PR TITLE
4.0.0 and 3.6.2: Add resource limits to install-cni.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ version directory, and then changes are introduced.
 - Enabled admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
 - Use patched GiantSwarm build of Kubernetes (`hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm`).
 - Updated Calico to 3.2.3
-- Updated Calico manifest with resource limits.
+- Updated Calico manifest with resource limits to get QoS policy guaranteed.
 
 ## [v3.6.2]
 
 ### Changed
 - Updated Calico to 3.2.3
-- Updated Calico manifest with resource limits.
+- Updated Calico manifest with resource limits to get QoS policy guaranteed.
 - Enabled admission plugins: DefaultTolerationSeconds, MutatingAdmissionWebhook, ValidatingAdmissionWebhook.
 
 ## [v3.6.1]

--- a/v_3_6_2/master_template.go
+++ b/v_3_6_2/master_template.go
@@ -23,8 +23,9 @@ write_files:
   permissions: 644
   content: |
     # Extra changes:
-    #  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
-    #  - added resource limits
+    #  - Added "nodename_file_optional" set to true (can be removed on the next upgrade).
+    #  - Added resource limits to calico-node and calico-kube-controllers.
+    #  - Added resource limits to install-cni.
     #
     # Calico Version v3.2.3
     # https://docs.projectcalico.org/v3.2/releases#v3.2.3
@@ -294,6 +295,15 @@ write_files:
                     configMapKeyRef:
                       name: calico-config
                       key: veth_mtu
+              # install-cni also monitors etcd certificates,
+              # so use reasonable resource limits.
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 100Mi
+                limits:
+                  cpu: 50m
+                  memory: 100Mi
               volumeMounts:
                 - mountPath: /host/opt/cni/bin
                   name: cni-bin-dir

--- a/v_4_0_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_0_0/files/k8s-resource/calico-all.yaml
@@ -1,6 +1,7 @@
 # Extra changes:
-#  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
-#  - added resource limits
+#  - Added "nodename_file_optional" set to true (can be removed on the next upgrade).
+#  - Added resource limits to calico-node and calico-kube-controller.
+#  - Added resource limits to install-cni.
 #
 # Calico Version v3.2.3
 # https://docs.projectcalico.org/v3.2/releases#v3.2.3
@@ -265,6 +266,15 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
+          # install-cni also monitors etcd certificates,
+          # so use reasonable resource limits.
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
Part of: https://github.com/giantswarm/giantswarm/issues/4159

Now we get QoS policy guaranteed.