### PR TITLE
k8s 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ version directory, and then changes are introduced.
 - Updated Calico to 3.2.3
 - Updated Calico manifest with resource limits to get QoS policy guaranteed.
 
+## [v3.7.0]
+
+### Changed
+- Updated Kubernetes to 1.12.1
+- Updated etcd to 3.3.9
+- Kubernetes and etcd images are now held in one place
+
 ## [v3.6.2]
 
 ### Changed

--- a/v_3_7_0/cloudconfig.go
+++ b/v_3_7_0/cloudconfig.go
@@ -13,6 +13,8 @@ import (
 
 const (
 	defaultRegistryDomain = "quay.io"
+	kubernetesImage       = "giantswarm/hyperkube:v1.12.1"
+	etcdImage             = "giantswarm/etcd:v3.3.9"
 )
 
 type CloudConfigConfig struct {
@@ -49,6 +51,12 @@ func NewCloudConfig(config CloudConfigConfig) (*CloudConfig, error) {
 	if config.Params.RegistryDomain == "" {
 		config.Params.RegistryDomain = defaultRegistryDomain
 	}
+	// Set the kubernetes/etcd images since they are used multiple times
+	config.Params.Images = Images{
+		Kubernetes: kubernetesImages,
+		Etcd:       etcdImage,
+	}
+
 	// extract cluster base domain
 	config.Params.BaseDomain = strings.TrimPrefix(config.Params.Cluster.Kubernetes.API.Domain, "api.")
 

--- a/v_3_7_0/cloudconfig.go
+++ b/v_3_7_0/cloudconfig.go
@@ -53,7 +53,7 @@ func NewCloudConfig(config CloudConfigConfig) (*CloudConfig, error) {
 	}
 	// Set the kubernetes/etcd images since they are used multiple times
 	config.Params.Images = Images{
-		Kubernetes: kubernetesImages,
+		Kubernetes: kubernetesImage,
 		Etcd:       etcdImage,
 	}
 

--- a/v_3_7_0/master_template.go
+++ b/v_3_7_0/master_template.go
@@ -2250,7 +2250,7 @@ coreos:
       -v /usr/sbin/mkfs.xfs:/usr/sbin/mkfs.xfs \
       -v /usr/lib64/libxfs.so.0:/usr/lib/libxfs.so.0 \
       -v /usr/lib64/libxcmd.so.0:/usr/lib/libxcmd.so.0 \
-      -v /usr/lib64/libreadline.so.6:/usr/lib/libreadline.so.6 \
+      -v /usr/lib64/libreadline.so.7:/usr/lib/libreadline.so.7 \
       -e ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd/server-ca.pem \
       -e ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd/server-crt.pem \
       -e ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd/server-key.pem \
@@ -2265,7 +2265,6 @@ coreos:
       --containerized \
       --enable-server \
       --logtostderr=true \
-      --cadvisor-port=4194 \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --network-plugin=cni \
       --register-node=true \

--- a/v_3_7_0/master_template.go
+++ b/v_3_7_0/master_template.go
@@ -937,7 +937,7 @@ write_files:
           serviceAccountName: kube-proxy
           containers:
             - name: kube-proxy
-              image: {{ .RegistryDomain }}/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
+              image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
               command:
               - /hyperkube
               - proxy
@@ -1715,7 +1715,7 @@ write_files:
       priorityClassName: system-node-critical
       containers:
       - name: k8s-api-server
-        image: {{ .RegistryDomain }}/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
+        image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
         env:
         - name: HOST_IP
           valueFrom:
@@ -1838,7 +1838,7 @@ write_files:
       priorityClassName: system-node-critical
       containers:
       - name: k8s-controller-manager
-        image: {{ .RegistryDomain }}/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
+        image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
         command:
         - /hyperkube
         - controller-manager
@@ -1911,7 +1911,7 @@ write_files:
       priorityClassName: system-node-critical
       containers:
       - name: k8s-scheduler
-        image: {{ .RegistryDomain }}/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm
+        image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
         command:
         - /hyperkube
         - scheduler
@@ -2118,7 +2118,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
-      Environment=IMAGE={{ .RegistryDomain }}/giantswarm/etcd:v3.3.8
+      Environment=IMAGE={{ .RegistryDomain }}/{{ .Images.Etcd }}
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
@@ -2167,7 +2167,7 @@ coreos:
       [Service]
       Type=oneshot
       EnvironmentFile=/etc/network-environment
-      Environment=IMAGE={{ .RegistryDomain }}/giantswarm/etcd:v3.3.3
+      Environment=IMAGE={{ .RegistryDomain }}/{{ .Images.Etcd }}
       Environment=NAME=%p.service
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
@@ -2215,7 +2215,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{ .RegistryDomain }}/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm"
+      Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_7_0/types.go
+++ b/v_3_7_0/types.go
@@ -47,10 +47,17 @@ type Params struct {
 	// RegistryDomain is the host of the docker image registry to use.
 	RegistryDomain string
 	SSOPublicKey   string
+	// Container images used in the cloud-config templates
+	Images Images
 }
 
 func (p *Params) Validate() error {
 	return nil
+}
+
+type Images struct {
+	Kubernetes string
+	Etcd       string
 }
 
 type Hyperkube struct {

--- a/v_3_7_0/worker_template.go
+++ b/v_3_7_0/worker_template.go
@@ -311,7 +311,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{ .RegistryDomain }}/giantswarm/hyperkube:v1.11.1-cec4fb8023db783fbf26fb056bf6c76abfcd96cf-giantswarm"
+      Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_7_0/worker_template.go
+++ b/v_3_7_0/worker_template.go
@@ -311,7 +311,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}
+      Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE

--- a/v_3_7_0/worker_template.go
+++ b/v_3_7_0/worker_template.go
@@ -345,7 +345,7 @@ coreos:
       -v /usr/sbin/mkfs.xfs:/usr/sbin/mkfs.xfs \
       -v /usr/lib64/libxfs.so.0:/usr/lib/libxfs.so.0 \
       -v /usr/lib64/libxcmd.so.0:/usr/lib/libxcmd.so.0 \
-      -v /usr/lib64/libreadline.so.6:/usr/lib/libreadline.so.6 \
+      -v /usr/lib64/libreadline.so.7:/usr/lib/libreadline.so.7 \
       -e ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd/client-ca.pem \
       -e ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd/client-crt.pem \
       -e ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd/client-key.pem \
@@ -360,7 +360,6 @@ coreos:
       --containerized \
       --enable-server \
       --logtostderr=true \
-      --cadvisor-port=4194 \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --network-plugin=cni \
       --register-node=true \


### PR DESCRIPTION
to make replacing the k8s version a bit easier i've factored the images
that are used multiple times into constants. the etcd image was already
different for the server and for backups.