### PR TITLE
update audit policy api version

### DIFF
--- a/v_3_7_0/master_template.go
+++ b/v_3_7_0/master_template.go
@@ -1688,7 +1688,7 @@ write_files:
   owner: root
   permissions: 0644
   content: |
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     rules:
       # TODO: Filter safe system requests.


### PR DESCRIPTION
Should fix this error 

```
file.go:187] Can't process manifest file "/etc/kubernetes/manifests/audit-policy.yml": /etc/kubernetes/manifests/audit-policy.yml:  couldn't parse as pod(no kind "Policy" is registered for version "audit.k8s.io/v1beta1" in scheme "k8s.io/kubernetes/pkg/api/legacyscheme/scheme.go:29"), please check config file
```