### PR TITLE
remove anonymous access to kubelet

### DIFF
--- a/v_3_7_0/master_template.go
+++ b/v_3_7_0/master_template.go
@@ -1578,14 +1578,6 @@ write_files:
     evictionSoftGracePeriod:
       memory.available: "5s"
     evictionMaxPodGracePeriod: 60
-    authentication:
-      anonymous:
-        enabled: true # Defaults to false as of 1.10
-      webhook:
-        enabled: false # Deafults to true as of 1.10
-    authorization:
-      mode: AlwaysAllow # Deafults to webhook as of 1.10
-    readOnlyPort: 10255 # Used by heapster. Defaults to 0 (disabled) as of 1.10. Needed for metrics.
 - path: /etc/kubernetes/config/kubelet-kubeconfig.yml
   owner: root
   permissions: 0644

--- a/v_3_7_0/master_template.go
+++ b/v_3_7_0/master_template.go
@@ -1724,6 +1724,8 @@ write_files:
         - --anonymous-auth=false
         - --insecure-port=0
         - --kubelet-https=true
+		- --kubelet-client-certificate=/etc/kubernetes/ssl/apiserver-crt.pem
+		- --kubelet-client-key=/etc/kubernetes/ssl/apiserver-key.pem
         - --kubelet-preferred-address-types=InternalIP
         - --secure-port={{.Cluster.Kubernetes.API.SecurePort}}
         - --bind-address=$(HOST_IP)

--- a/v_3_7_0/worker_template.go
+++ b/v_3_7_0/worker_template.go
@@ -69,14 +69,6 @@ write_files:
     evictionSoftGracePeriod:
       memory.available: "5s"
     evictionMaxPodGracePeriod: 60
-    authentication:
-      anonymous:
-        enabled: true # Defaults to false as of 1.10
-      webhook:
-        enabled: false # Deafults to true as of 1.10
-    authorization:
-      mode: AlwaysAllow # Deafults to webhook as of 1.10
-    readOnlyPort: 10255 # Used by heapster. Defaults to 0 (disabled) as of 1.10. Needed for metrics.
 - path: /etc/kubernetes/config/kubelet-kubeconfig.yml
   owner: root
   permissions: 0644


### PR DESCRIPTION
removed specific configuration for kubelet access and auth to go with
the upstream defaults.

See:
https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration.Authentication

Also removed the readonly port that was used by heapster.