### PR TITLE
remove static pod path from worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ version directory, and then changes are introduced.
 - Updated audit policy version
 - Moved audit policy out of static pod path
 - Updated rbac resources to v1
+- Remove static pod path from worker nodes
 
 ## [v3.6.2]
 

--- a/v_3_7_0/worker_template.go
+++ b/v_3_7_0/worker_template.go
@@ -62,7 +62,6 @@ write_files:
     clusterDNS:
       - {{.Cluster.Kubernetes.DNS.IP}}
     clusterDomain: {{.Cluster.Kubernetes.Domain}}
-    staticPodPath: /etc/kubernetes/manifests
     evictionSoft:
       memory.available: "500Mi"
     evictionHard:


### PR DESCRIPTION
we don't have any pod manifests on workers. 

kubelet on workers logs:

```
Unable to read config path "/etc/kubernetes/manifests": path does not exist, ignoring
```