### PR TITLE
remove readonly port from kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ version directory, and then changes are introduced.
 - Moved audit policy out of static pod path
 - Updated rbac resources to v1
 - Remove static pod path from worker nodes
+- Remove readonly port from kubelet
 
 ## [v3.6.2]
 

--- a/v_3_7_0/master_template.go
+++ b/v_3_7_0/master_template.go
@@ -1585,7 +1585,6 @@ write_files:
         enabled: false # Deafults to true as of 1.10
     authorization:
       mode: AlwaysAllow # Deafults to webhook as of 1.10
-    readOnlyPort: 10255 # Used by heapster. Defaults to 0 (disabled) as of 1.10. Needed for metrics.
 - path: /etc/kubernetes/config/kubelet-kubeconfig.yml
   owner: root
   permissions: 0644

--- a/v_3_7_0/worker_template.go
+++ b/v_3_7_0/worker_template.go
@@ -76,7 +76,6 @@ write_files:
         enabled: false # Deafults to true as of 1.10
     authorization:
       mode: AlwaysAllow # Deafults to webhook as of 1.10
-    readOnlyPort: 10255 # Used by heapster. Defaults to 0 (disabled) as of 1.10. Needed for metrics.
 - path: /etc/kubernetes/config/kubelet-kubeconfig.yml
   owner: root
   permissions: 0644


### PR DESCRIPTION
this port was used by heapster before. heapster got replaced so there is
no need to keep the port.