### PR TITLE
install kube-proxy in master before calico

### DIFF
--- a/v_3_7_1/master_template.go
+++ b/v_3_7_1/master_template.go
@@ -1436,6 +1436,19 @@ write_files:
           done
       done
 
+      PROXY_MANIFESTS="kube-proxy-sa.yaml kube-proxy-ds.yaml"
+      for manifest in $PROXY_MANIFESTS
+      do
+          while
+              /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+              [ "$?" -ne "0" ]
+          do
+              echo "failed to apply /srv/$manifest, retrying in 5 sec"
+              sleep 5s
+          done
+      done
+      echo "kube-proxy successfully installed"
+
       {{ if not .DisableCalico -}}
 
       # apply calico
@@ -1482,8 +1495,6 @@ write_files:
       {{ range .ExtraManifests -}}
       MANIFESTS="${MANIFESTS} {{ . }}"
       {{ end -}}
-      MANIFESTS="${MANIFESTS} kube-proxy-sa.yaml"
-      MANIFESTS="${MANIFESTS} kube-proxy-ds.yaml"
       {{ if not .DisableCoreDNS }}
       MANIFESTS="${MANIFESTS} coredns.yaml"
       {{ end -}}


### PR DESCRIPTION
during an upgrade calico was not coming up. so the proxy stayed at 1.10
although the cluster was already 1.12. so since the proxy is not
dependent on calico we can just install it before we are installing and
waiting for calico.