### PR TITLE
Restart master kubelet after running core components

### DIFF
--- a/v_4_0_0/master_template.go
+++ b/v_4_0_0/master_template.go
@@ -301,6 +301,8 @@ systemd:
       Type=oneshot
       EnvironmentFile=/etc/network-environment
       ExecStart=/opt/k8s-addons
+      # https://github.com/kubernetes/kubernetes/issues/71078
+      ExecStartPost=/usr/bin/systemctl restart k8s-kubelet.service
       [Install]
       WantedBy=multi-user.target
 


### PR DESCRIPTION
The ugliest workaround you'll find today on the internet. 
But this thing just blocks me from moving with ignition and k8s 1.13. 
Upstream issue: https://github.com/kubernetes/kubernetes/issues/71078
Shortly - kubelet loses connection in the middle of booting and can't restore it. Happens only to master. Restarting container helps. 