### PR TITLE
Remove nodename_file_optional from calico configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ version directory, and then changes are introduced.
 ### Removed
 
 - Ingress Controller and CoreDNS manifests. Now migrated to chart-operator.
+- Removed nodename_file_optional from calico configmap.
 
 ## [v3.7.4] WIP
 
@@ -25,6 +26,7 @@ version directory, and then changes are introduced.
 - Double the inotify watches.
 
 ### Removed
+- Removed nodename_file_optional from calico configmap.
 
 ## [v3.7.3]
 

--- a/v_3_7_4/master_template.go
+++ b/v_3_7_4/master_template.go
@@ -27,7 +27,6 @@ write_files:
     # where X is the version of azure operator
     #
     # Extra changes:
-    #  - Added "nodename_file_optional" set to true (can be removed on the next upgrade).
     #  - Added resource limits to calico-node and calico-kube-controllers.
     #  - Added resource limits to install-cni.
     #  - Added 'priorityClassName: system-cluster-critical' to calico daemonset.
@@ -75,7 +74,6 @@ write_files:
               "etcd_cert_file": "__ETCD_CERT_FILE__",
               "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
               "mtu": __CNI_MTU__,
-              "nodename_file_optional": true,
               "ipam": {
                   "type": "calico-ipam"
               },

--- a/v_4_0_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_0_0/files/k8s-resource/calico-all.yaml
@@ -3,7 +3,6 @@
 # where X is the version of azure operator
 #
 # Extra changes:
-#  - Added "nodename_file_optional" set to true (can be removed on the next upgrade).
 #  - Added resource limits to calico-node and calico-kube-controller.
 #  - Added resource limits to install-cni.
 #  - Added 'priorityClassName: system-cluster-critical' to calico daemonset.
@@ -51,7 +50,6 @@ data:
           "etcd_cert_file": "__ETCD_CERT_FILE__",
           "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
           "mtu": __CNI_MTU__,
-          "nodename_file_optional": true,
           "ipam": {
               "type": "calico-ipam"
           },


### PR DESCRIPTION
related: https://github.com/giantswarm/giantswarm/issues/4113