### PR TITLE
adds worker role labels

### DIFF
--- a/v_4_0_0/worker_template.go
+++ b/v_4_0_0/worker_template.go
@@ -164,7 +164,7 @@ systemd:
       --network-plugin=cni \
       --register-node=true \
       --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
-      --node-labels="ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --node-labels="node-role.kubernetes.io/worker,role=worker,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
       --v=2"
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
We were wondering why there are no worker role labels. The change here is pretty simple. What could possibly go wrong? I checked some upstream issues and only found concerns of master role labels being applied in an uncontrolled way. So we should be safe. Further I am not sure why we should have two different labels for that. 