### PR TITLE
increase-timeout-for-etcd-defrag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ version directory, and then changes are introduced.
 - Double the inotify watches.
 - Switch kube-proxy from `iptables` to `ipvs`.
 - Add worker node labels.
+- Increase timeouts for etcd defragmentaion.
 
 ### Removed
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 - 2019 GiantSwarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/v_4_0_0/master_template.go
+++ b/v_4_0_0/master_template.go
@@ -179,7 +179,10 @@ systemd:
         --cacert /etc/etcd/server-ca.pem \
         --cert /etc/etcd/server-crt.pem \
         --key /etc/etcd/server-key.pem \
-        defrag
+        defrag \
+        --command-timeout=60s \
+        --dial-timeout=60s \
+        --keepalive-timeout=25s
       [Install]
       WantedBy=multi-user.target
   - name: etcd3-defragmentation.timer


### PR DESCRIPTION
Sometimes on overloaded master etcd-defragmentation can take a little longer and the default timeout can be very low.

Just adjusting limits so we see less failed units ( and have more reliable defragmentation)