### PR TITLE
switch kube-proxy back to iptables

### DIFF
--- a/v_4_1_0/files/config/kube-proxy.yaml
+++ b/v_4_1_0/files/config/kube-proxy.yaml
@@ -2,6 +2,6 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 clientConnection:
   kubeconfig: /etc/kubernetes/config/proxy-kubeconfig.yaml
 kind: KubeProxyConfiguration
-mode: ipvs
+mode: iptables
 resourceContainer: /kube-proxy
 clusterCIDR: {{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}


### PR DESCRIPTION
ipvs is still experimental and with 1.12.x clusters we are still having
issues with it. so for now we go back to 'iptables'