### PR TITLE
CVE-2019-1002100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ version directory, and then changes are introduced.
 
 ## [v4.1.0] WIP
 ### Changed
+- Update kubernetes to 1.13.4 CVE-2019-1002100
 - Intall calicoctl, crictl and configure etcctl tooling in masters.
 - Update kubernetes to 1.13.3.
 - Update etcd to 3.3.12.
@@ -18,6 +19,7 @@ version directory, and then changes are introduced.
 - Add fine-grained Audit Policy
 
 ## [v3.8.0] WIP
+- Update kubernetes to 1.13.4 CVE-2019-1002100
 
 ## [v4.0.0]
 

--- a/v_3_8_0/cloudconfig.go
+++ b/v_3_8_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	defaultRegistryDomain = "quay.io"
-	kubernetesImage       = "giantswarm/hyperkube:v1.12.3"
+	kubernetesImage       = "giantswarm/hyperkube:v1.12.6"
 	etcdImage             = "giantswarm/etcd:v3.3.9"
 )
 

--- a/v_4_1_0/cloudconfig.go
+++ b/v_4_1_0/cloudconfig.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultRegistryDomain = "quay.io"
-	kubernetesImage       = "giantswarm/hyperkube:v1.13.3"
+	kubernetesImage       = "giantswarm/hyperkube:v1.13.4"
 	etcdImage             = "giantswarm/etcd:v3.3.12"
 	etcdPort              = 443
 )


### PR DESCRIPTION
FIxes CVE-2019-1002100 
A denial of service vulnerability was reported in kube-apiserver in which authorized users with API write permissions can cause the API server to consume excessive resources while handling a write request. 

The issue is medium severity and can be resolved by upgrading the kube-apiserver to v1.12.6, or v1.13.4.
