### PR TITLE
Added 4_0_1 for kubernetes 1.12.6

### DIFF
--- a/v_4_0_1/cloudconfig.go
+++ b/v_4_0_1/cloudconfig.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultRegistryDomain = "quay.io"
-	kubernetesImage       = "giantswarm/hyperkube:v1.12.3"
+	kubernetesImage       = "giantswarm/hyperkube:v1.12.6"
 	etcdImage             = "giantswarm/etcd:v3.3.9"
 	etcdPort              = 443
 )

--- a/v_4_0_1/cloudconfig_test.go
+++ b/v_4_0_1/cloudconfig_test.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"encoding/base64"

--- a/v_4_0_1/common_template_test.go
+++ b/v_4_0_1/common_template_test.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 type nopWriter struct{}
 

--- a/v_4_0_1/error.go
+++ b/v_4_0_1/error.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import "github.com/giantswarm/microerror"
 

--- a/v_4_0_1/filemanager.go
+++ b/v_4_0_1/filemanager.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version  = "v_4_0_0"
+	version  = "v_4_0_1"
 	filesDir = "files"
 )
 
@@ -60,7 +60,7 @@ func GetIgnitionPath(ignitionDir string) string {
 }
 
 // GetPackagePath returns top package path for the current runtime file.
-// For example, for /go/src/k8scloudconfig/v_4_0_0/file.go function
+// For example, for /go/src/k8scloudconfig/v_4_0_1/file.go function
 // returns /go/src/k8scloudconfig.
 // This function used only in tests for retrieving ignition assets in runtime.
 func GetPackagePath() (string, error) {

--- a/v_4_0_1/filemanager_test.go
+++ b/v_4_0_1/filemanager_test.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"bytes"

--- a/v_4_0_1/master_template.go
+++ b/v_4_0_1/master_template.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 const MasterTemplate = `---
 ignition:

--- a/v_4_0_1/master_template_test.go
+++ b/v_4_0_1/master_template_test.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"testing"

--- a/v_4_0_1/render_asset_content.go
+++ b/v_4_0_1/render_asset_content.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"bytes"

--- a/v_4_0_1/render_asset_content_test.go
+++ b/v_4_0_1/render_asset_content_test.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"strings"

--- a/v_4_0_1/types.go
+++ b/v_4_0_1/types.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"

--- a/v_4_0_1/worker_template.go
+++ b/v_4_0_1/worker_template.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 const WorkerTemplate = `---
 ignition:

--- a/v_4_0_1/worker_template_test.go
+++ b/v_4_0_1/worker_template_test.go
@@ -1,4 +1,4 @@
-package v_4_0_0
+package v_4_0_1
 
 import (
 	"testing"


### PR DESCRIPTION
We need to create a new version for aws-operator(4.6.1) which must be to run on kubernetes version 1.12.6

