### PR TITLE
Allow kube-proxy to tolerate all NoSchedule taint

### DIFF
--- a/v_4_3_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_3_0/files/k8s-resource/calico-all.yaml
@@ -118,14 +118,11 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
-        # Make sure calico-node gets scheduled on all nodes.
-        - effect: NoSchedule
-          operator: Exists
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - effect: NoExecute
-          operator: Exists
+        # Make sure the pod gets scheduled on all nodes.
+        - operator: Exists
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force

--- a/v_4_3_0/files/k8s-resource/kube-proxy-ds.yaml
+++ b/v_4_3_0/files/k8s-resource/kube-proxy-ds.yaml
@@ -25,9 +25,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - effect: NoSchedule
         operator: Exists
-        effect: NoSchedule
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy

--- a/v_4_3_0/files/k8s-resource/kube-proxy-ds.yaml
+++ b/v_4_3_0/files/k8s-resource/kube-proxy-ds.yaml
@@ -25,8 +25,9 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      - effect: NoSchedule
+      - key: CriticalAddonsOnly
         operator: Exists
+      - operator: Exists
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy

--- a/v_4_3_0/files/k8s-resource/kube-proxy-ds.yaml
+++ b/v_4_3_0/files/k8s-resource/kube-proxy-ds.yaml
@@ -25,8 +25,10 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
+      # Mark the pod as a critical add-on for rescheduling.
       - key: CriticalAddonsOnly
         operator: Exists
+      # Make sure the pod gets scheduled on all nodes.
       - operator: Exists
       hostNetwork: true
       priorityClassName: system-node-critical


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5744

We encountered an issue where `kube-proxy` was not scheduled on some node due to them having the following taint:
```
 taints:
 - effect: NoSchedule
   key: NodeWithImpairedVolumes
   value: "true"
```

Therefore we need to have `kube-proxy` tolerating every `NoSchedule` taint and not only the ones with `key: node-role.kubernetes.io/master`.

How about aligning toleration with calico and adding toleration for `CriticalAddonsOnly` and `NoExecute` also ?
https://github.com/giantswarm/k8scloudconfig/blob/80b22e313bd60f651c8f24456e366931ef2a347d/v_4_3_0/files/k8s-resource/calico-all.yaml#L120-L128