### PR TITLE
Update changelog: kube-proxy and calico taint toleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ version directory, and  then changes are introduced.
 - Update kubernetes to 1.14.1
 - Update calico to 3.6.1
 - Change node labels for master and workers
+- Update kube-proxy and calico to tolerate every taint effects and CriticalAddonsOnly
 
 ## [v4.2.0]
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5744

Forgot to update changelog earlier.

Update changelog about taint toleration for kube-proxy and calico.