### PR TITLE
Add felix metric server for expose calico metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ version directory, and  then changes are introduced.
 
 ### Changed
 
+-- Change Felix configuration to add metric server and expose data to be scraped for prometheus.
+
 ## [v4.3.0]
 
 ### Changed

--- a/v_4_3_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_3_0/files/k8s-resource/calico-all.yaml
@@ -251,6 +251,8 @@ spec:
               value: "Warning"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "true"
           securityContext:
             privileged: true
           resources:

--- a/v_4_3_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_3_0/files/k8s-resource/calico-all.yaml
@@ -251,8 +251,6 @@ spec:
               value: "Warning"
             - name: FELIX_HEALTHENABLED
               value: "true"
-            - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "true"
           securityContext:
             privileged: true
           resources:

--- a/v_4_4_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_4_0/files/k8s-resource/calico-all.yaml
@@ -251,6 +251,8 @@ spec:
               value: "Warning"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "true"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
Expose Felix metrics in calico, so we or customers can use Prometheus to scrape Felix state.