### PR TITLE
Add cpu memmory and filesystem evictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ version directory, and  then changes are introduced.
 ### Changed
 
 -- Change Felix configuration to add metric server and expose data to be scraped for prometheus.
+-- Add cpu/mem reservation for kubelet and system processes.	
+-- Add eviction in worker nodes when image and node filesystems are less than 5% and 10%
 
 ## [v4.3.0]
 

--- a/v_4_4_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_4_0/files/config/kubelet-master.yaml.tmpl
@@ -10,11 +10,21 @@ clusterDomain: {{.Cluster.Kubernetes.Domain}}
 staticPodPath: /etc/kubernetes/manifests
 evictionSoft:
   memory.available: "500Mi"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "10%"
+evictionSoftGracePeriod:
+  memory.available: "30s"
+  imagefs.available: "30s"
+  nodefs.inodesFree: "30s"
 evictionHard:
   memory.available: "200Mi"
-evictionSoftGracePeriod:
-  memory.available: "5s"
 evictionMaxPodGracePeriod: 60
+systemReserved:
+  cpu: "250m"
+  memory: "0.2Gi"
+kubeReserved:
+  cpu: "250m"
+  memory: "1Gi"
 authentication:
   anonymous:
     enabled: true # Defaults to false as of 1.10

--- a/v_4_4_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_4_0/files/config/kubelet-worker.yaml.tmpl
@@ -9,11 +9,21 @@ clusterDNS:
 clusterDomain: {{.Cluster.Kubernetes.Domain}}
 evictionSoft:
   memory.available: "500Mi"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "10%"
+evictionSoftGracePeriod:
+  memory.available: "30s"
+  imagefs.available: "30s"
+  nodefs.inodesFree: "30s"
 evictionHard:
   memory.available: "200Mi"
-evictionSoftGracePeriod:
-  memory.available: "5s"
 evictionMaxPodGracePeriod: 60
+systemReserved:
+  cpu: "250m"
+  memory: "0.2Gi"
+kubeReserved:
+  cpu: "250m"
+  memory: "1Gi"
 authentication:
   anonymous:
     enabled: true # Defaults to false as of 1.10


### PR DESCRIPTION
Still testing how it works in tenant clusters.

- Add cpu/mem reservation for kubelet and system processes.	
- Add eviction in worker nodes when image and node filesystems are less than 5% and 10%

Towards: https://github.com/giantswarm/giantswarm/issues/6030