### PR TITLE
Move ic performance improvements into os provisioning

### DIFF
--- a/v_4_4_0/files/conf/hardening.conf
+++ b/v_4_4_0/files/conf/hardening.conf
@@ -10,3 +10,7 @@ net.ipv6.conf.all.accept_redirects = 0
 net.ipv6.conf.default.accept_redirects = 0
 # Increased mmapfs because some applications, like ES, need higher limit to store data properly
 vm.max_map_count = 262144
+# Ingress controller performance improvements
+# See https://github.com/kubernetes/ingress-nginx/issues/1939
+net.core.somaxconn=32768
+net.ipv4.ip_local_port_range="1024 65535"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5983

This will allow to drop initContainer with sysctl, which requires psp to allow privileged containers