### PR TITLE
Use new owner structure

### DIFF
--- a/v_4_4_0/master_template.go
+++ b/v_4_4_0/master_template.go
@@ -544,9 +544,17 @@ storage:
     - path: {{ .Metadata.Path }}
       filesystem: root
       user:
-        name: {{ .Metadata.Owner.User }}
+      {{- if .Metadata.Owner.User.ID }}
+        id: {{ .Metadata.Owner.User.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.User.Name }}
+      {{- end }}
       group:
-        name: {{ .Metadata.Owner.Group }}
+      {{- if .Metadata.Owner.Group.ID }}
+        id: {{ .Metadata.Owner.Group.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.Group.Name }}
+      {{- end }}
       mode: {{printf "%#o" .Metadata.Permissions}}
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{ .Content }}"

--- a/v_4_4_0/types.go
+++ b/v_4_4_0/types.go
@@ -101,11 +101,15 @@ type Owner struct {
 	User  User
 }
 
+// Group object reflects spec for ignition Group object.
+// If both ID and name are specified, ID is preferred.
 type Group struct {
 	ID   int
 	Name string
 }
 
+// User object reflects spec for ignition User object.
+// If both ID and name are specified, ID is preferred.
 type User struct {
 	ID   int
 	Name string

--- a/v_4_4_0/types.go
+++ b/v_4_4_0/types.go
@@ -97,8 +97,18 @@ type FileMetadata struct {
 }
 
 type Owner struct {
-	User  string
-	Group string
+	Group Group
+	User  User
+}
+
+type Group struct {
+	ID   int
+	Name string
+}
+
+type User struct {
+	ID   int
+	Name string
 }
 
 type FileAsset struct {

--- a/v_4_4_0/worker_template.go
+++ b/v_4_4_0/worker_template.go
@@ -262,9 +262,17 @@ storage:
     - path: {{ .Metadata.Path }}
       filesystem: root
       user:
-        name: {{ .Metadata.Owner.User }}
+      {{- if .Metadata.Owner.User.ID }}
+        id: {{ .Metadata.Owner.User.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.User.Name }}
+      {{- end }}
       group:
-        name: {{ .Metadata.Owner.Group }}
+      {{- if .Metadata.Owner.Group.ID }}
+        id: {{ .Metadata.Owner.Group.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.Group.Name }}
+      {{- end }}
       mode: {{printf "%#o" .Metadata.Permissions}}
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{ .Content }}"


### PR DESCRIPTION
This PR aligns Owner structure with ignition spec and allows to use `id` of the group instead of name. Required for this https://github.com/giantswarm/azure-operator/pull/519