### PR TITLE
Fix hardening formatting

### DIFF
--- a/v_4_4_0/files/conf/hardening.conf
+++ b/v_4_4_0/files/conf/hardening.conf
@@ -13,4 +13,4 @@ vm.max_map_count = 262144
 # Ingress controller performance improvements
 # See https://github.com/kubernetes/ingress-nginx/issues/1939
 net.core.somaxconn=32768
-net.ipv4.ip_local_port_range="1024 65535"
+net.ipv4.ip_local_port_range=1024 65535


### PR DESCRIPTION
This article actually mentions that this setting in a file is set without `"`:
https://www.cyberciti.biz/tips/linux-increase-outgoing-network-sockets-range.html

I tested it and this fixes the following failure:
```
Jun 12 13:12:54 localhost systemd-sysctl[1006]: Couldn't write '"1024 65535"' to 'net/ipv4/ip_local_port_range': Invalid argument
```