### PR TITLE
Drop giantswarm namespace from labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ version directory, and  then changes are introduced.
 
 ## [v4.5.0] WIP
 - Add configuration necessery for generic support of rbd storage.
-- Add `name` label for `kube-system`, `default` and `giantswarm` namespaces.
+- Add `name` label for `kube-system` and `default` namespaces.
 
 ## [v4.4.0]
 

--- a/v_4_5_0/files/conf/k8s-addons
+++ b/v_4_5_0/files/conf/k8s-addons
@@ -10,7 +10,7 @@ KUBECTL={{ .RegistryDomain }}/giantswarm/docker-kubectl:f5cae44c480bd797dc770dd5
 while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
 
 # label namespaces (required for network egress policies)
-NAMESPACES="default giantswarm kube-system" 
+NAMESPACES="default kube-system" 
 for namespace in ${NAMESPACES}
 do
     while


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4033
Namespace is not there for a time of k8s-addons execution