### PR TITLE
Use v1 stable for priority class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ version directory, and  then changes are introduced.
 ## [v4.5.0] WIP
 - Add configuration necessery for generic support of rbd storage.
 - Add `name` label for `kube-system` and `default` namespaces.
+- Update `giantswarm-critical` priority class manifest to use `v1` stable.
 
 ## [v4.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ version directory, and  then changes are introduced.
 
 ## [v4.6.0] WIP
 
-### Changed
+### Fixed
 
 - Update `giantswarm-critical` priority class manifest to use `v1` stable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@ version directory, and  then changes are introduced.
 
 ## [v4.6.0] WIP
 
+### Changed
+
+- Update `giantswarm-critical` priority class manifest to use `v1` stable.
+
 ## [v4.5.0]
 
 ### Changed
 
 - Add configuration necessery for generic support of rbd storage.
 - Add `name` label for `kube-system` and `default` namespaces.
-- Update `giantswarm-critical` priority class manifest to use `v1` stable.
 
 ## [v4.4.0]
 

--- a/v_4_5_0/files/k8s-resource/priority_classes.yaml
+++ b/v_4_5_0/files/k8s-resource/priority_classes.yaml
@@ -1,4 +1,4 @@
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: giantswarm-critical

--- a/v_4_5_0/files/k8s-resource/priority_classes.yaml
+++ b/v_4_5_0/files/k8s-resource/priority_classes.yaml
@@ -1,4 +1,4 @@
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1alpha1
 kind: PriorityClass
 metadata:
   name: giantswarm-critical

--- a/v_4_6_0/files/k8s-resource/priority_classes.yaml
+++ b/v_4_6_0/files/k8s-resource/priority_classes.yaml
@@ -1,4 +1,4 @@
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: giantswarm-critical


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6405

Priority classes graduated to stable in 1.14. So this gets the manifest sorted.