### PR TITLE
Make image pull progress deadline configurable for kubelets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ version directory, and  then changes are introduced.
 
 ## [v4.6.0] WIP
 
+### Changed
+
+- Make --image-pull-progress-deadline configurable for kubelets so a longer
+duration can be used in AWS China regions to mitigate slow image pulls.
+
 ## [v4.5.0]
 
 ### Changed

--- a/v_4_6_0/cloudconfig.go
+++ b/v_4_6_0/cloudconfig.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	defaultRegistryDomain = "quay.io"
-	kubernetesImage       = "giantswarm/hyperkube:v1.14.3"
-	etcdImage             = "giantswarm/etcd:v3.3.13"
-	etcdPort              = 443
+	defaultRegistryDomain            = "quay.io"
+	defaultImagePullProgressDeadline = "1m"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.14.3"
+	etcdImage                        = "giantswarm/etcd:v3.3.13"
+	etcdPort                         = 443
 )
 
 type CloudConfigConfig struct {
@@ -37,6 +38,7 @@ func DefaultParams() Params {
 			Kubernetes: kubernetesImage,
 			Etcd:       etcdImage,
 		},
+		ImagePullProgressDeadline: defaultImagePullProgressDeadline,
 	}
 }
 

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -260,6 +260,7 @@ systemd:
       --enable-server \
       --logtostderr=true \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
+      --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
       --network-plugin=cni \
       --register-node=true \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/v_4_6_0/types.go
+++ b/v_4_6_0/types.go
@@ -37,7 +37,10 @@ type Params struct {
 	// then apply the manifest by adding it to ExtraManifests.
 	ExtraManifests []string
 	Files          Files
-	Node           v1alpha1.ClusterNode
+	// ImagePullProgressDeadline is the duration after which image pulling is
+	// cancelled if no progress has been made.
+	ImagePullProgressDeadline string
+	Node                      v1alpha1.ClusterNode
 	// RegistryDomain is the host of the docker image registry to use.
 	RegistryDomain string
 	SSOPublicKey   string

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -161,6 +161,7 @@ systemd:
       --enable-server \
       --logtostderr=true \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
+      --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
       --network-plugin=cni \
       --register-node=true \
       --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6367

Makes `--image-pull-progress-deadline` configurable for kubelets with a default of 1 minute. We will increase this to 10 minutes for tenant clusters in AWS China regions. This mitigates the extremely slow image pulls we see there which are outside of our control.

This happened in control plane clusters a long time ago and we decided to implement for tenants as well.


> --image-pull-progress-deadline duration
>  If no pulling progress is made before this deadline, the image pulling will be cancelled. (default 1m0s)

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/