### PR TITLE
improve etcd retry policy and wait for domains

### DIFF
--- a/v_4_2_0/files/conf/wait-for-domains
+++ b/v_4_2_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_4_2_0/master_template.go
+++ b/v_4_2_0/master_template.go
@@ -105,7 +105,7 @@ systemd:
     contents: |
       [Unit]
       Description=etcd3
-      Requires=k8s-setup-network-env.service
+      Wants=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
       Conflicts=etcd.service etcd2.service
       StartLimitIntervalSec=0

--- a/v_4_3_0/files/conf/wait-for-domains
+++ b/v_4_3_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_4_3_0/master_template.go
+++ b/v_4_3_0/master_template.go
@@ -105,7 +105,7 @@ systemd:
     contents: |
       [Unit]
       Description=etcd3
-      Requires=k8s-setup-network-env.service
+      Wants=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
       Conflicts=etcd.service etcd2.service
       StartLimitIntervalSec=0

--- a/v_4_4_0/files/conf/wait-for-domains
+++ b/v_4_4_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_4_4_0/master_template.go
+++ b/v_4_4_0/master_template.go
@@ -105,7 +105,7 @@ systemd:
     contents: |
       [Unit]
       Description=etcd3
-      Requires=k8s-setup-network-env.service
+      Wants=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
       Conflicts=etcd.service etcd2.service
       StartLimitIntervalSec=0

--- a/v_4_5_0/files/conf/wait-for-domains
+++ b/v_4_5_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_4_5_0/master_template.go
+++ b/v_4_5_0/master_template.go
@@ -113,7 +113,7 @@ systemd:
     contents: |
       [Unit]
       Description=etcd3
-      Requires=k8s-setup-network-env.service
+      Wants=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
       Conflicts=etcd.service etcd2.service
       StartLimitIntervalSec=0

--- a/v_4_6_0/files/conf/wait-for-domains
+++ b/v_4_6_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}}"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -113,7 +113,7 @@ systemd:
     contents: |
       [Unit]
       Description=etcd3
-      Requires=k8s-setup-network-env.service
+      Wants=k8s-setup-network-env.service
       After=k8s-setup-network-env.service
       Conflicts=etcd.service etcd2.service
       StartLimitIntervalSec=0


### PR DESCRIPTION
this change cames out of the test we have here https://github.com/giantswarm/aws-operator/pull/1752 and the goal was to improve AWS e2e test as they were often flaky

One of the findings was that sometimes the DNS in AWS ins unreliable, it can resolve local domains but timeouts on global domains, that bring some confusion and failures

When k8s-setup-network-env failed than etcd3 failed too because of failed dependency and never started again. Usually, the k8s-setup-network-env self-healed in time but etcd3 was dead.  Setting `Wants` instead of `Require` causes that etcd3 will start and fail but the restart policy will keep th etcd3 restating until it can start and that helped in the AWS e2e a lot.


another change is adding an external domain to `wait-for-domain` to ensure we can resolve `quay.io` because it's essential for most of the environments, I tested that all installation can resolve this DNS so should not be a problem