### PR TITLE
Make rbd usable via Kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ version directory, and  then changes are introduced.
 
 ## [v4.6.0] WIP
 
+### Changed
+
+- Mount relevant directories so that the command `docker` can run in `Kubelet`. This is needed for `rbd` to mount `Ceph` volumes on the nodes.
+
 ### Fixed
 
 - Update `giantswarm-critical` priority class manifest to use `v1` stable.

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -216,7 +216,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"
-      Environment="PATH=/opt/bin/:/usr/bin/:/usr/sbin:/sbin:$PATH"
+      Environment="PATH=/opt/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       ExecStartPre=/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
@@ -231,6 +231,9 @@ systemd:
       -v /run/calico/:/run/calico/:rw \
       -v /run/docker/:/run/docker/:rw \
       -v /run/docker.sock:/run/docker.sock:rw \
+      -v /usr/bin/docker:/usr/bin/docker \
+      -v /run/metadata/torcx:/run/metadata/torcx \
+      -v /run/torcx/:/run/torcx/ \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
       -v /var/lib/calico/:/var/lib/calico \

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -118,7 +118,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"
-      Environment="PATH=/opt/bin/:/usr/bin/:/usr/sbin:/sbin:$PATH"
+      Environment="PATH=/opt/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       ExecStartPre=/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
@@ -133,6 +133,9 @@ systemd:
       -v /run/calico/:/run/calico/:rw \
       -v /run/docker/:/run/docker/:rw \
       -v /run/docker.sock:/run/docker.sock:rw \
+      -v /usr/bin/docker:/usr/bin/docker \
+      -v /run/metadata/torcx:/run/metadata/torcx \
+      -v /run/torcx/:/run/torcx/ \
       -v /usr/lib/os-release:/etc/os-release \
       -v /usr/share/ca-certificates/:/etc/ssl/certs \
       -v /var/lib/calico/:/var/lib/calico \


### PR DESCRIPTION
Full `PATH` is set since `$PATH` can't be used in systemd unit files. I took the path from a running instance.

The rbd tool wants to run `docker` and for this mounting of `/usr/bin/docker` `/run/metadata/torcx` and `/run/torcx/` on CoreOS.

I don't know about using `ro` `rw` or `rshared` on these, so please advise.