### PR TITLE
Custom cgroup structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ version directory, and  then changes are introduced.
 ### Changed
 
 - Mount relevant directories so that the command `docker` can run in `Kubelet`. This is needed for `rbd` to mount `Ceph` volumes on the nodes.
+- Add explicit cgroups for better grained resources management over operating system components and container runtime.
 
 ### Fixed
 

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -16,15 +16,15 @@ evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
 kubeReserved:
-  cpu: 500m
-  memory: 512Mi
+  cpu: 250m
+  memory: 768Mi
   ephemeral-storage: 1024Mi
 kubeReservedCgroup: /podruntime.slice
 kubeletCgroups: /podruntime.slice
 runtimeCgroups: /podruntime.slice
 systemReserved:
-  cpu: 500m
-  memory: 512Mi
+  cpu: 250m
+  memory: 384Mi
 systemReservedCgroup: /system.slice
 authentication:
   anonymous:

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -16,8 +16,8 @@ evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
 kubeReserved:
-  cpu: 350m
-  memory: 1024Mi
+  cpu: 400m
+  memory: 1280Mi
   ephemeral-storage: 1024Mi
 kubeReservedCgroup: /kubereserved.slice
 kubeletCgroups: /kubereserved.slice

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -15,6 +15,10 @@ evictionHard:
 evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
+enforceNodeAllocatable:
+  - pods
+  - kube-reserved
+  - system-reserved
 kubeReserved:
   cpu: 500m
   memory: 512Mi

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -19,9 +19,9 @@ kubeReserved:
   cpu: 350m
   memory: 1024Mi
   ephemeral-storage: 1024Mi
-kubeReservedCgroup: /podruntime.slice
-kubeletCgroups: /podruntime.slice
-runtimeCgroups: /podruntime.slice
+kubeReservedCgroup: /kubereserved.slice
+kubeletCgroups: /kubereserved.slice
+runtimeCgroups: /kubereserved.slice
 systemReserved:
   cpu: 250m
   memory: 384Mi

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -15,6 +15,17 @@ evictionHard:
 evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
+kubeReserved:
+  cpu: 500m
+  memory: 512Mi
+  ephemeral-storage: 1024Mi
+kubeReservedCgroup: /podruntime.slice
+kubeletCgroups: /podruntime.slice
+runtimeCgroups: /podruntime.slice
+systemReserved:
+  cpu: 500m
+  memory: 512Mi
+systemReservedCgroup: /system.slice
 authentication:
   anonymous:
     enabled: true # Defaults to false as of 1.10

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -15,10 +15,6 @@ evictionHard:
 evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
-enforceNodeAllocatable:
-  - pods
-  - kube-reserved
-  - system-reserved
 kubeReserved:
   cpu: 500m
   memory: 512Mi

--- a/v_4_6_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-master.yaml.tmpl
@@ -16,8 +16,8 @@ evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
 kubeReserved:
-  cpu: 250m
-  memory: 768Mi
+  cpu: 350m
+  memory: 1024Mi
   ephemeral-storage: 1024Mi
 kubeReservedCgroup: /podruntime.slice
 kubeletCgroups: /podruntime.slice

--- a/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
@@ -14,6 +14,17 @@ evictionHard:
 evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
+kubeReserved:
+  cpu: 500m
+  memory: 512Mi
+  ephemeral-storage: 1024Mi
+kubeReservedCgroup: /podruntime.slice
+kubeletCgroups: /podruntime.slice
+runtimeCgroups: /podruntime.slice
+systemReserved:
+  cpu: 500m
+  memory: 512Mi
+systemReservedCgroup: /system.slice
 authentication:
   anonymous:
     enabled: true # Defaults to false as of 1.10

--- a/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
@@ -14,6 +14,10 @@ evictionHard:
 evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
+enforceNodeAllocatable:
+  - pods
+  - kube-reserved
+  - system-reserved
 kubeReserved:
   cpu: 500m
   memory: 512Mi

--- a/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
@@ -15,7 +15,7 @@ evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
 kubeReserved:
-  cpu: 250m
+  cpu: 300m
   memory: 768Mi
   ephemeral-storage: 1024Mi
 kubeReservedCgroup: /kubereserved.slice

--- a/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
@@ -15,15 +15,15 @@ evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
 kubeReserved:
-  cpu: 500m
-  memory: 512Mi
+  cpu: 250m
+  memory: 768Mi
   ephemeral-storage: 1024Mi
 kubeReservedCgroup: /podruntime.slice
 kubeletCgroups: /podruntime.slice
 runtimeCgroups: /podruntime.slice
 systemReserved:
-  cpu: 500m
-  memory: 512Mi
+  cpu: 250m
+  memory: 384Mi
 systemReservedCgroup: /system.slice
 authentication:
   anonymous:

--- a/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
@@ -18,9 +18,9 @@ kubeReserved:
   cpu: 250m
   memory: 768Mi
   ephemeral-storage: 1024Mi
-kubeReservedCgroup: /podruntime.slice
-kubeletCgroups: /podruntime.slice
-runtimeCgroups: /podruntime.slice
+kubeReservedCgroup: /kubereserved.slice
+kubeletCgroups: /kubereserved.slice
+runtimeCgroups: /kubereserved.slice
 systemReserved:
   cpu: 250m
   memory: 384Mi

--- a/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_6_0/files/config/kubelet-worker.yaml.tmpl
@@ -14,10 +14,6 @@ evictionHard:
 evictionSoftGracePeriod:
   memory.available: "5s"
 evictionMaxPodGracePeriod: 60
-enforceNodeAllocatable:
-  - pods
-  - kube-reserved
-  - system-reserved
 kubeReserved:
   cpu: 500m
   memory: 512Mi

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -44,6 +44,8 @@ systemd:
     - name: 10-change-user-session-cgroup.conf
       contents: |
         [Service]
+        CPUAccounting=true
+        MemoryAccounting=true
         Slice=system-user-%i.slice
   # End - manual management for cgroup structure
   - name: audit-rules.service
@@ -115,6 +117,8 @@ systemd:
       - name: 10-change-cgroup.conf
         contents: |
           [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
           Slice=podruntime.slice
   - name: docker.service
     enabled: true
@@ -123,6 +127,8 @@ systemd:
       - name: 10-giantswarm-extra-args.conf
         contents: |
           [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
           Slice=podruntime.slice
           Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
@@ -253,6 +259,8 @@ systemd:
       Restart=always
       RestartSec=0
       TimeoutStopSec=10
+      CPUAccounting=true
+      MemoryAccounting=true
       Slice=podruntime.slice
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -27,6 +27,16 @@ passwd:
 
 systemd:
   units:
+  - name: podruntime-slice
+    path: /etc/systemd/system/podruntime.slice
+    content: |
+      [Unit]
+      Description=Limited resources slice for Kubernetes services
+      Documentation=man:systemd.special(7)
+      DefaultDependencies=no
+      Before=slices.target
+      Requires=-.slice
+      After=-.slice
   - name: audit-rules.service
     enabled: true
     dropins:

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -38,15 +38,6 @@ systemd:
       Before=slices.target
       Requires=-.slice
       After=-.slice
-  - name: user@.service
-    enabled: true
-    dropins:
-    - name: 10-change-user-session-cgroup.conf
-      contents: |
-        [Service]
-        CPUAccounting=true
-        MemoryAccounting=true
-        Slice=system-user-%i.slice
   # End - manual management for cgroup structure
   - name: audit-rules.service
     enabled: true
@@ -168,6 +159,9 @@ systemd:
       RestartSec=0
       TimeoutStopSec=10
       LimitNOFILE=40000
+      CPUAccounting=true
+      MemoryAccounting=true
+      Slice=podruntime.slice
       Environment=IMAGE={{ .RegistryDomain }}/{{ .Images.Etcd }}
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -27,6 +27,7 @@ passwd:
 
 systemd:
   units:
+  # Start - manual management for cgroup structure
   - name: podruntime-slice
     path: /etc/systemd/system/podruntime.slice
     content: |
@@ -37,6 +38,14 @@ systemd:
       Before=slices.target
       Requires=-.slice
       After=-.slice
+  - name: user@.service
+    enabled: true
+    dropins:
+    - name: 10-change-user-session-cgroup.conf
+      contents: |
+        [Service]
+        Slice=system-user-%i.slice
+  # End - manual management for cgroup structure
   - name: audit-rules.service
     enabled: true
     dropins:

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -108,6 +108,14 @@ systemd:
       ExecStart=/bin/bash -c '/usr/bin/envsubst </etc/kubernetes/config/kubelet.yaml.tmpl >/etc/kubernetes/config/kubelet.yaml'
       [Install]
       WantedBy=multi-user.target
+  - name: containerd.service
+    enabled: true
+    contents: |
+    dropins:
+      - name: 10-change-cgroup.conf
+        contents: |
+          [Service]
+          Slice=podruntime.slice
   - name: docker.service
     enabled: true
     contents: |
@@ -115,6 +123,7 @@ systemd:
       - name: 10-giantswarm-extra-args.conf
         contents: |
           [Service]
+          Slice=podruntime.slice
           Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
           Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
@@ -244,6 +253,7 @@ systemd:
       Restart=always
       RestartSec=0
       TimeoutStopSec=10
+      Slice=podruntime.slice
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -121,7 +121,7 @@ systemd:
           CPUAccounting=true
           MemoryAccounting=true
           Slice=podruntime.slice
-          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/podruntime.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
           Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
   - name: k8s-setup-network-env.service
@@ -180,7 +180,6 @@ systemd:
           $IMAGE \
           etcd \
           --name etcd0 \
-          --cgroup-parent=/podruntime.slice \
           --trusted-ca-file /etc/etcd/server-ca.pem \
           --cert-file /etc/etcd/server-crt.pem \
           --key-file /etc/etcd/server-key.pem\
@@ -309,7 +308,6 @@ systemd:
       {{ range .Hyperkube.Kubelet.Docker.CommandExtraArgs -}}
       {{ . }} \
       {{ end -}}
-      --cgroup-parent=/podruntime.slice \
       --node-ip=${DEFAULT_IPV4} \
       --config=/etc/kubernetes/config/kubelet.yaml \
       --containerized \

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -28,8 +28,8 @@ passwd:
 systemd:
   units:
   # Start - manual management for cgroup structure
-  - name: podruntime.slice
-    path: /etc/systemd/system/podruntime.slice
+  - name: kubereserved.slice
+    path: /etc/systemd/system/kubereserved.slice
     content: |
       [Unit]
       Description=Limited resources slice for Kubernetes services
@@ -110,7 +110,7 @@ systemd:
           [Service]
           CPUAccounting=true
           MemoryAccounting=true
-          Slice=podruntime.slice
+          Slice=kubereserved.slice
   - name: docker.service
     enabled: true
     contents: |
@@ -120,8 +120,8 @@ systemd:
           [Service]
           CPUAccounting=true
           MemoryAccounting=true
-          Slice=podruntime.slice
-          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/podruntime.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+          Slice=kubereserved.slice
+          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/kubereserved.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
           Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
   - name: k8s-setup-network-env.service
@@ -161,7 +161,7 @@ systemd:
       LimitNOFILE=40000
       CPUAccounting=true
       MemoryAccounting=true
-      Slice=podruntime.slice
+      Slice=kubereserved.slice
       Environment=IMAGE={{ .RegistryDomain }}/{{ .Images.Etcd }}
       Environment=NAME=%p.service
       EnvironmentFile=/etc/network-environment
@@ -255,7 +255,7 @@ systemd:
       TimeoutStopSec=10
       CPUAccounting=true
       MemoryAccounting=true
-      Slice=podruntime.slice
+      Slice=kubereserved.slice
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -28,7 +28,7 @@ passwd:
 systemd:
   units:
   # Start - manual management for cgroup structure
-  - name: podruntime-slice
+  - name: podruntime.slice
     path: /etc/systemd/system/podruntime.slice
     content: |
       [Unit]

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -180,6 +180,7 @@ systemd:
           $IMAGE \
           etcd \
           --name etcd0 \
+          --cgroup-parent=/podruntime.slice \
           --trusted-ca-file /etc/etcd/server-ca.pem \
           --cert-file /etc/etcd/server-crt.pem \
           --key-file /etc/etcd/server-key.pem\
@@ -308,6 +309,7 @@ systemd:
       {{ range .Hyperkube.Kubelet.Docker.CommandExtraArgs -}}
       {{ . }} \
       {{ end -}}
+      --cgroup-parent=/podruntime.slice \
       --node-ip=${DEFAULT_IPV4} \
       --config=/etc/kubernetes/config/kubelet.yaml \
       --containerized \

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -27,6 +27,7 @@ passwd:
 
 systemd:
   units:
+  # Start - manual management for cgroup structure
   - name: podruntime-slice
     path: /etc/systemd/system/podruntime.slice
     content: |
@@ -37,6 +38,14 @@ systemd:
       Before=slices.target
       Requires=-.slice
       After=-.slice
+  - name: user@.service
+    enabled: true
+    dropins:
+    - name: 10-change-user-session-cgroup.conf
+      contents: |
+        [Service]
+        Slice=system-user-%i.slice
+  # End - manual management for cgroup structure
   {{range .Extension.Units}}
   - name: {{.Metadata.Name}}
     enabled: {{.Metadata.Enabled}}

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -28,8 +28,8 @@ passwd:
 systemd:
   units:
   # Start - manual management for cgroup structure
-  - name: podruntime.slice
-    path: /etc/systemd/system/podruntime.slice
+  - name: kubereserved.slice
+    path: /etc/systemd/system/kubereserved.slice
     content: |
       [Unit]
       Description=Limited resources slice for Kubernetes services
@@ -103,7 +103,7 @@ systemd:
           [Service]
           CPUAccounting=true
           MemoryAccounting=true
-          Slice=podruntime.slice
+          Slice=kubereserved.slice
   - name: docker.service
     enabled: true
     contents: |
@@ -113,8 +113,8 @@ systemd:
           [Service]
           CPUAccounting=true
           MemoryAccounting=true
-          Slice=podruntime.slice
-          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/podruntime.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+          Slice=kubereserved.slice
+          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/kubereserved.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
           Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
   - name: k8s-setup-network-env.service
@@ -154,7 +154,7 @@ systemd:
       TimeoutStopSec=10
       CPUAccounting=true
       MemoryAccounting=true
-      Slice=podruntime.slice
+      Slice=kubereserved.slice
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
       Environment="NAME=%p.service"

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -44,6 +44,8 @@ systemd:
     - name: 10-change-user-session-cgroup.conf
       contents: |
         [Service]
+        CPUAccounting=true
+        MemoryAccounting=true
         Slice=system-user-%i.slice
   # End - manual management for cgroup structure
   {{range .Extension.Units}}
@@ -108,6 +110,8 @@ systemd:
       - name: 10-change-cgroup.conf
         contents: |
           [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
           Slice=podruntime.slice
   - name: docker.service
     enabled: true
@@ -116,6 +120,8 @@ systemd:
       - name: 10-giantswarm-extra-args.conf
         contents: |
           [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
           Slice=podruntime.slice
           Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
@@ -155,6 +161,8 @@ systemd:
       Restart=always
       RestartSec=0
       TimeoutStopSec=10
+      CPUAccounting=true
+      MemoryAccounting=true
       Slice=podruntime.slice
       EnvironmentFile=/etc/network-environment
       Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -114,7 +114,7 @@ systemd:
           CPUAccounting=true
           MemoryAccounting=true
           Slice=podruntime.slice
-          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/podruntime.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
           Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
           Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
   - name: k8s-setup-network-env.service
@@ -206,7 +206,6 @@ systemd:
       {{ range .Hyperkube.Kubelet.Docker.CommandExtraArgs -}}
       {{ . }} \
       {{ end -}}
-      --cgroup-parent=/podruntime.slice \
       --node-ip=${DEFAULT_IPV4} \
       --config=/etc/kubernetes/config/kubelet.yaml \
       --containerized \

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -38,15 +38,6 @@ systemd:
       Before=slices.target
       Requires=-.slice
       After=-.slice
-  - name: user@.service
-    enabled: true
-    dropins:
-    - name: 10-change-user-session-cgroup.conf
-      contents: |
-        [Service]
-        CPUAccounting=true
-        MemoryAccounting=true
-        Slice=system-user-%i.slice
   # End - manual management for cgroup structure
   {{range .Extension.Units}}
   - name: {{.Metadata.Name}}

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -206,6 +206,7 @@ systemd:
       {{ range .Hyperkube.Kubelet.Docker.CommandExtraArgs -}}
       {{ . }} \
       {{ end -}}
+      --cgroup-parent=/podruntime.slice \
       --node-ip=${DEFAULT_IPV4} \
       --config=/etc/kubernetes/config/kubelet.yaml \
       --containerized \

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -27,6 +27,16 @@ passwd:
 
 systemd:
   units:
+  - name: podruntime-slice
+    path: /etc/systemd/system/podruntime.slice
+    content: |
+      [Unit]
+      Description=Limited resources slice for Kubernetes services
+      Documentation=man:systemd.special(7)
+      DefaultDependencies=no
+      Before=slices.target
+      Requires=-.slice
+      After=-.slice
   {{range .Extension.Units}}
   - name: {{.Metadata.Name}}
     enabled: {{.Metadata.Enabled}}

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -28,7 +28,7 @@ passwd:
 systemd:
   units:
   # Start - manual management for cgroup structure
-  - name: podruntime-slice
+  - name: podruntime.slice
     path: /etc/systemd/system/podruntime.slice
     content: |
       [Unit]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6270

## What was changed?

### New `kubereserved` cgroup.
- `docker` daemon moved from root cgroup into kubereserved. 
- `kubelet` and `etcd` systemd services moved under `kubereserved` cgroup. This is not that important, as containers itself are placed into cgroups by docker daemon configuration. But this change was done to keep related things better structured
- with `--parent-cgroup` configuration, all the containers, started by docker without k8s context (e.g. kubelet/etcd) are started under `kubereserved` cgroup.
 
### Explicit reservation of the resources via kubelet config.

- `SystemReserved` configuration explicitly points to `system` cgroup and has explicitly reserved resources.
- `Kubereserved` configuration has explicitly reserved resources.

This means, that there will be less allocatable resources for nodes:
```
[Allocatable] = [Node Capacity] - [Kube-Reserved] - [System-Reserved]
```

Allocation enforcement was not changed. That means, that resource allocation forced only for pods (`kubepods` cgroup). If kubereserved/systemdreserved cgroup will need more memory - they can take more. But for pods it is enforced to stay in `Allocatable` limits

Exact numbers were taken from best practices docs, discussions on GitHub and some performance tests on test clusters. We can adjust those numbers over time while testing in real production.

----

New cgroup structure looks like:

```
+-- -.slice
+-- system.slice. Reserved: **250m** CPU, **384Mi** memory
|   +-- sshd
|   +-- systemd
|   +-- udevd
|   +-- networkd
|   +-- ...
+-- kubereserved.slice (new cgroup). Reserved(master/worker): **400m**/**300** CPU, **1280Mi**/**768Mi** memory
|   +-- docker daemon
|   +-- containerd
|   +-- docker containers, started out of k8s context, e.g. kubelet, etcd
+-- user.slice - no reserved resources explicitly
|   +-- user sessions
+-- kubepods
|   +-- besteffort
|   +-- burstable
|   +-- guaranteed 
```

