### PR TITLE
Node exporter systemd unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ version directory, and  then changes are introduced.
 ### Added
 
 - Systemd unit, which sets certificates group owner to `giantswarm`, so that cert-exporter running as user `giantswarm` is able to read certificates.
+- node-exporter as systemd unit instead of daemonset in Kubernetes.
 
 ### Changed
 

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -325,6 +325,51 @@ systemd:
       ExecStopPost=-/usr/bin/docker rm -f $NAME
       [Install]
       WantedBy=multi-user.target
+  - name: node-exporter.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Node Exporter
+
+      [Service]
+      ExecStartPre=/bin/sh -c "docker rm -f node-exporter-binarycopy; \
+                  docker create --name node-exporter-binarycopy {{ .RegistryDomain }}/node-exporter:v0.18.0-giantswarm && \
+                  docker cp node-exporter-binarycopy:/bin/node_exporter /opt/bin/node_exporter && \
+                  docker rm -f node-exporter-binarycopy"
+      ExecStart=/opt/bin/node_exporter \
+                --log.level=info \
+                --web.listen-address=:10300 \
+                --collector.arp \
+                --collector.bcache \
+                --collector.conntrack \
+                --collector.cpu \
+                --collector.edac \
+                --collector.entropy \
+                --collector.filefd \
+                --collector.filesystem \
+                --collector.hwmon \
+                --collector.loadavg \
+                --collector.mdadm \
+                --collector.meminfo \
+                --collector.netdev \
+                --collector.netstat \
+                --collector.sockstat \
+                --collector.stat \
+                --collector.systemd \
+                --collector.time \
+                --collector.timex \
+                --collector.uname \
+                --collector.vmstat \
+                --collector.xfs \
+                --no-collector.diskstats \
+                --no-collector.infiniband \
+                --no-collector.ipvs \
+                --no-collector.textfile \
+                --no-collector.wifi \
+                --no-collector.zfs
+
+      [Install]
+      WantedBy=multi-user.target
   - name: etcd2.service
     enabled: false
     mask: true

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -330,6 +330,8 @@ systemd:
     contents: |
       [Unit]
       Description=Node Exporter
+      After=k8s-setup-network-env.service docker.service
+      Requires=k8s-setup-network-env.service docker.service
 
       [Service]
       ExecStartPre=/bin/sh -c "docker rm -f node-exporter-binarycopy; \

--- a/v_4_6_0/master_template.go
+++ b/v_4_6_0/master_template.go
@@ -334,6 +334,8 @@ systemd:
       Requires=k8s-setup-network-env.service docker.service
 
       [Service]
+      Restart=on-failure
+      RestartSec=5s
       ExecStartPre=/bin/sh -c "docker rm -f node-exporter-binarycopy; \
                   docker create --name node-exporter-binarycopy {{ .RegistryDomain }}/node-exporter:v0.18.0-giantswarm && \
                   docker cp node-exporter-binarycopy:/bin/node_exporter /opt/bin/node_exporter && \

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -231,6 +231,8 @@ systemd:
       Requires=k8s-setup-network-env.service docker.service
 
       [Service]
+      Restart=on-failure
+      RestartSec=5s
       ExecStartPre=/bin/sh -c "docker rm -f node-exporter-binarycopy; \
                   docker create --name node-exporter-binarycopy {{ .RegistryDomain }}//node-exporter:v0.18.0 && \
                   docker cp node-exporter-binarycopy:/bin/node_exporter /opt/bin/node_exporter && \

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -229,7 +229,7 @@ systemd:
       Description=Node Exporter
       After=k8s-setup-network-env.service docker.service
       Requires=k8s-setup-network-env.service docker.service
-  
+
       [Service]
       ExecStartPre=/bin/sh -c "docker rm -f node-exporter-binarycopy; \
                   docker create --name node-exporter-binarycopy {{ .RegistryDomain }}//node-exporter:v0.18.0 && \
@@ -266,7 +266,7 @@ systemd:
                 --no-collector.textfile \
                 --no-collector.wifi \
                 --no-collector.zfs
-  
+
       [Install]
       WantedBy=multi-user.target
   - name: etcd2.service

--- a/v_4_6_0/worker_template.go
+++ b/v_4_6_0/worker_template.go
@@ -222,6 +222,53 @@ systemd:
       ExecStopPost=-/usr/bin/docker rm -f $NAME
       [Install]
       WantedBy=multi-user.target
+  - name: node-exporter.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Node Exporter
+      After=k8s-setup-network-env.service docker.service
+      Requires=k8s-setup-network-env.service docker.service
+  
+      [Service]
+      ExecStartPre=/bin/sh -c "docker rm -f node-exporter-binarycopy; \
+                  docker create --name node-exporter-binarycopy {{ .RegistryDomain }}//node-exporter:v0.18.0 && \
+                  docker cp node-exporter-binarycopy:/bin/node_exporter /opt/bin/node_exporter && \
+                  docker rm -f node-exporter-binarycopy"
+      ExecStart=/opt/bin/node_exporter \
+                --log.level=info \
+                --web.listen-address=:10300 \
+                --collector.arp \
+                --collector.bcache \
+                --collector.conntrack \
+                --collector.cpu \
+                --collector.edac \
+                --collector.entropy \
+                --collector.filefd \
+                --collector.filesystem \
+                --collector.hwmon \
+                --collector.loadavg \
+                --collector.mdadm \
+                --collector.meminfo \
+                --collector.netdev \
+                --collector.netstat \
+                --collector.sockstat \
+                --collector.stat \
+                --collector.systemd \
+                --collector.time \
+                --collector.timex \
+                --collector.uname \
+                --collector.vmstat \
+                --collector.xfs \
+                --no-collector.diskstats \
+                --no-collector.infiniband \
+                --no-collector.ipvs \
+                --no-collector.textfile \
+                --no-collector.wifi \
+                --no-collector.zfs
+  
+      [Install]
+      WantedBy=multi-user.target
   - name: etcd2.service
     enabled: false
     mask: true


### PR DESCRIPTION
Moving node-exporter from container into systemd unit. 

This will help us
 - solve all the issues related with access to OS info.
 - keeping CoreOS and node-exporter versions in sync (another thing which causes issues every now and then)

---

Unit is using little hack to copy binary from container so we can solve distribution issue for China.
With next PR I'll remove node-exporter from current WIP version in cluster-operator.
Would be nice to sync this back to control-plane