### PR TITLE
v_4_7_0 imports and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ The latest version is considered WIP and it is a subject of change. All other
 versions are frozen. To freeze current version all files are copied to a new
 version directory, and  then changes are introduced.
 
-## [v4.6.0] WIP
+## [v4.7.0] WIP
+
+### TODO
+
+## [v4.6.0]
 
 ### Added
 
@@ -424,6 +428,7 @@ chart-operator).
 
 ## [v0.1.0]
 
+[v4.7.0]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_4_7_0
 [v4.6.0]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_4_6_0
 [v4.5.1]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_4_5_1
 [v4.5.0]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_4_5_0

--- a/v_4_7_0/cloudconfig.go
+++ b/v_4_7_0/cloudconfig.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"bytes"

--- a/v_4_7_0/cloudconfig_test.go
+++ b/v_4_7_0/cloudconfig_test.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"encoding/base64"

--- a/v_4_7_0/common_template_test.go
+++ b/v_4_7_0/common_template_test.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 type nopWriter struct{}
 

--- a/v_4_7_0/error.go
+++ b/v_4_7_0/error.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import "github.com/giantswarm/microerror"
 

--- a/v_4_7_0/filemanager.go
+++ b/v_4_7_0/filemanager.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version  = "v_4_6_0"
+	version  = "v_4_7_0"
 	filesDir = "files"
 )
 

--- a/v_4_7_0/filemanager_test.go
+++ b/v_4_7_0/filemanager_test.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"bytes"

--- a/v_4_7_0/master_template.go
+++ b/v_4_7_0/master_template.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 const MasterTemplate = `---
 ignition:

--- a/v_4_7_0/master_template_test.go
+++ b/v_4_7_0/master_template_test.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"testing"

--- a/v_4_7_0/render_asset_content.go
+++ b/v_4_7_0/render_asset_content.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"bytes"

--- a/v_4_7_0/render_asset_content_test.go
+++ b/v_4_7_0/render_asset_content_test.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"strings"

--- a/v_4_7_0/types.go
+++ b/v_4_7_0/types.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"

--- a/v_4_7_0/worker_template.go
+++ b/v_4_7_0/worker_template.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 const WorkerTemplate = `---
 ignition:

--- a/v_4_7_0/worker_template_test.go
+++ b/v_4_7_0/worker_template_test.go
@@ -1,4 +1,4 @@
-package v_4_6_0
+package v_4_7_0
 
 import (
 	"testing"


### PR DESCRIPTION
We use `v_4_6_0` in an active azure release now. See here:
https://github.com/giantswarm/azure-operator/blob/d46da3a0418cfbd2d107f574bc470c2d4b532fbd/service/controller/v9/cloudconfig/worker_template.go#L8

I create a new folder for k8scc to not accidentally disturb production of active releases with WIP merges.