### PR TITLE
Remove Get List Watch from audit logs per default

### DIFF
--- a/v_4_8_0/files/policies/audit-policy.yaml
+++ b/v_4_8_0/files/policies/audit-policy.yaml
@@ -109,7 +109,7 @@ rules:
     omitStages:
       - "RequestReceived"
   # Get repsonses can be large; skip them.
-  - level: Request
+  - level: None
     verbs: ["get", "list", "watch"]
     resources:
       - group: "" # core


### PR DESCRIPTION

It generate a lot of logs, not necessary useful.
I think we can drop it as those verbs are more related to having access to the cluster.