### PR TITLE
add-k8s-api-healthz-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ version directory, and  then changes are introduced.
 
 ### Added
 
-- TODO
+- Add k8s-api-healthz service to master node to enable proper LB health checks to api and etcd.
 
 ## [v4.7.0]
 

--- a/v_4_9_0/files/manifests/k8s-api-healthz.yaml
+++ b/v_4_9_0/files/manifests/k8s-api-healthz.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s-api-healthz
+  namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  containers:
+    - name: k8s-api-healthz
+      env:
+      - name: HOST_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      command:
+        - /k8s-api-healthz
+        - --api-endpoint="https://$(HOST_IP):443/healthz"
+      image: quay.io/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
+      resources:
+        requests:
+          cpu: 50m
+          memory: 20Mi
+      volumeMounts:
+      - mountPath: /etc/kubernetes/ssl/
+        name: ssl-certs-kubernetes
+        readOnly: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes

--- a/v_4_9_0/master_template.go
+++ b/v_4_9_0/master_template.go
@@ -531,6 +531,11 @@ storage:
       mode: 0644
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{  index .Files "policies/audit-policy.yaml" }}"
+    - path: /etc/kubernetes/manifests/k8s-api-healthz.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "manifests/k8s-api-healthz.yaml" }}"
 
     - path: /etc/kubernetes/manifests/k8s-api-server.yaml
       filesystem: root


### PR DESCRIPTION
add healthz microservice also to TC

for now, it's just going to sit there, but we can later enable settings for all providers

I need this for further KVM without flannel testing

for https://github.com/giantswarm/giantswarm/issues/7151

We have this on cloud CPs and it works nicely. Also it get rid of the annoying spam error message in API logs about broken TLS connection.