### PR TITLE
expose kube-proxy metrics endpoint

### DIFF
--- a/v_4_9_0/files/config/kube-proxy.yaml
+++ b/v_4_9_0/files/config/kube-proxy.yaml
@@ -5,3 +5,4 @@ kind: KubeProxyConfiguration
 mode: iptables
 resourceContainer: /kube-proxy
 clusterCIDR: {{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}
+metricsBindAddress: 0.0.0.0:10249


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7159

This PR exposes the metric endpoint from kube-proxy, so customer can collect kube-proxy metrics.