### PR TITLE
Remove calico limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ version directory, and  then changes are introduced.
 ### Added
 
 - Bind kube-proxy metrics address to 0.0.0.0 instead on default 127.0.0.1 in config file.
+
+### Changed
+
 - Remove Calico Node limits.
 
 ## [v4.8.0] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ version directory, and  then changes are introduced.
 ### Added
 
 - Bind kube-proxy metrics address to 0.0.0.0 instead on default 127.0.0.1 in config file.
+- Remove Calico Node limits.
 
 ## [v4.8.0] 
 

--- a/v_4_9_0/files/k8s-resource/calico-all.yaml
+++ b/v_4_9_0/files/k8s-resource/calico-all.yaml
@@ -458,9 +458,6 @@ spec:
             requests:
               cpu: 250m
               memory: 150Mi
-            limits:
-              cpu: 250m
-              memory: 150Mi
           livenessProbe:
             httpGet:
               path: /liveness


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7022

For the new upcoming release, we'll remove Calico Node limits and let it burst. We have already in place an alert that notify us in case the memory used is equals to the one requested.