### PR TITLE
Use registry domain param for k8s-api-healthz and wait for domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ version directory, and  then changes are introduced.
 - Moved kubelet from container to host process (`--containerized` flag is removed in Kubernetes 1.16).
 - Switch from `iptables` to `ipvs` mode in kube-proxy and tune kernel params accordingly (all providers but azure).
 - Changed `restricted` PodSecurityPolicy to restrict the allowed range of user IDs for PODs.
+- Make image registry configurable in k8s-api-healthz and wait for domains script.
 
 ### Added
 

--- a/v_5_0_0/files/conf/wait-for-domains
+++ b/v_5_0_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} {{ .RegistryDomain }}"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_5_0_0/files/manifests/k8s-api-healthz.yaml
+++ b/v_5_0_0/files/manifests/k8s-api-healthz.yaml
@@ -18,7 +18,7 @@ spec:
       command:
         - /k8s-api-healthz
         - --api-endpoint="https://$(HOST_IP):443/healthz"
-      image: quay.io/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
+      image: {{ .RegistryDomain }}/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7773

Fixes 2 instances where the registry domain is hardcoded to quay.io. 