### PR TITLE
Revert IPVS to iptables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ version directory, and  then changes are introduced.
 ### Changed
 
 - Moved kubelet from container to host process (`--containerized` flag is removed in Kubernetes 1.16).
-- Switch from `iptables` to `ipvs` mode in kube-proxy and tune kernel params accordingly (all providers but azure).
 - Changed `restricted` PodSecurityPolicy to restrict the allowed range of user IDs for PODs.
 
 ### Added

--- a/v_5_0_0/files/conf/hardening.conf
+++ b/v_5_0_0/files/conf/hardening.conf
@@ -17,7 +17,3 @@ net.ipv4.ip_local_port_range=1024 65535
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.all.arp_ignore = 1
 net.ipv4.conf.all.arp_announce = 2
-{{- if ne .Cluster.Kubernetes.CloudProvider "azure" }}
-net.ipv4.vs.expire_nodest_conn = 1
-net.ipv4.tcp_retries2 = 5
-{{- end }}

--- a/v_5_0_0/files/config/kube-proxy.yaml
+++ b/v_5_0_0/files/config/kube-proxy.yaml
@@ -2,11 +2,7 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 clientConnection:
   kubeconfig: /etc/kubernetes/config/proxy-kubeconfig.yaml
 kind: KubeProxyConfiguration
-{{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
 mode: iptables
-{{- else }}
-mode: ipvs
-{{- end }}
 resourceContainer: /kube-proxy
 clusterCIDR: {{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}
 metricsBindAddress: 0.0.0.0:10249


### PR DESCRIPTION
After our discussion we'll rollback ipvs in other GS release and rely to fix network errors (iptables restore) on the upstream fix landing in k8s 1.16 coming with the upcoming GS release