### PR TITLE
Change Priority Class for calico-node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ version directory, and  then changes are introduced.
 - Moved kubelet from container to host process (`--containerized` flag is removed in Kubernetes 1.16).
 - Changed `restricted` PodSecurityPolicy to restrict the allowed range of user IDs for PODs.
 - Increase `fs.inotify.max_user_instances` to 8192.
+- Change Priority Class for `calico-node` to `system-node-critical`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ version directory, and  then changes are introduced.
 - Moved kubelet from container to host process (`--containerized` flag is removed in Kubernetes 1.16).
 - Changed `restricted` PodSecurityPolicy to restrict the allowed range of user IDs for PODs.
 - Increase `fs.inotify.max_user_instances` to 8192.
-- Change Priority Class for `calico-node` to `system-node-critical`
+- Change Priority Class for `calico-node` to `system-node-critical`.
 
 ### Added
 

--- a/v_5_0_0/files/k8s-resource/calico-all.yaml
+++ b/v_5_0_0/files/k8s-resource/calico-all.yaml
@@ -5,7 +5,7 @@
 # Extra changes:
 #  - Added resource limits to calico-node and calico-kube-controller.
 #  - Added resource limits to install-cni.
-#  - Added 'priorityClassName: system-cluster-critical' to calico daemonset.
+#  - Added 'priorityClassName: system-node-critical' to calico daemonset.
 #
 # Calico Version v3.9.1
 # https://docs.projectcalico.org/v3.9/release-notes/
@@ -312,7 +312,7 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       initContainers:
         # This container installs the CNI binaries
         # and CNI network config file on each node.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7939

Assign `system-node-critical` to `calico-node` to have a higher priority over all other resources in a node and avoid to be evicted.