### PR TITLE
Use registry domain for k8s-api-healthz and wait for domains script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ version directory, and  then changes are introduced.
 - Changed `restricted` PodSecurityPolicy to restrict the allowed range of user IDs for PODs.
 - Increase `fs.inotify.max_user_instances` to 8192.
 - Change Priority Class for `calico-node` to `system-node-critical`.
+- Use registry domain for k8s-api-healthz and wait for domains script for AWS China.
 
 ### Added
 

--- a/v_5_0_0/files/conf/wait-for-domains
+++ b/v_5_0_0/files/conf/wait-for-domains
@@ -1,5 +1,5 @@
 #!/bin/bash
-domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} {{ .RegistryDomain }}"
 
 for domain in $domains; do
 until nslookup $domain; do

--- a/v_5_0_0/files/manifests/k8s-api-healthz.yaml
+++ b/v_5_0_0/files/manifests/k8s-api-healthz.yaml
@@ -18,7 +18,7 @@ spec:
       command:
         - /k8s-api-healthz
         - --api-endpoint="https://$(HOST_IP):443/healthz"
-      image: quay.io/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
+      image:  {{ .RegistryDomain }}/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
       resources:
         requests:
           cpu: 50m

--- a/v_5_0_0/files/manifests/k8s-api-healthz.yaml
+++ b/v_5_0_0/files/manifests/k8s-api-healthz.yaml
@@ -18,7 +18,7 @@ spec:
       command:
         - /k8s-api-healthz
         - --api-endpoint="https://$(HOST_IP):443/healthz"
-      image:  {{ .RegistryDomain }}/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
+      image:  {{ .RegistryDomain }}/giantswarm/k8s-api-healthz:0999549a4c334b646288d08bd2c781c6aae2e12f
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7773

Fixes last 2 instances of `quay.io` hardcoding in `v_5_0_0`. This is so we use the retagged images in China.