### PR TITLE
Harden label service against kubelet flaps

### DIFF
--- a/v_5_0_0/master_template.go
+++ b/v_5_0_0/master_template.go
@@ -327,7 +327,6 @@ systemd:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      TimeoutStartSec=1200
       Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
       ExecStart=/bin/sh -c '\
         while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do sleep 1 && echo "Waiting for healthy k8s";done;sleep 30s; \

--- a/v_5_0_0/master_template.go
+++ b/v_5_0_0/master_template.go
@@ -323,13 +323,13 @@ systemd:
       [Unit]
       Description=Adds labels to the node after kubelet startup
       After=k8s-kubelet.service
-      Requires=k8s-kubelet.service
+      Wants=k8s-kubelet.service
       [Service]
       Type=oneshot
       RemainAfterExit=yes
       Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
       ExecStart=/bin/sh -c '\
-        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do sleep 1 && echo "Waiting for healthy k8s";done;sleep 30s; \
+        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         $KUBECTL label nodes --overwrite $(hostname) node-role.kubernetes.io/master=""; \
         $KUBECTL label nodes --overwrite $(hostname) kubernetes.io/role=master'
       [Install]

--- a/v_5_0_0/worker_template.go
+++ b/v_5_0_0/worker_template.go
@@ -199,13 +199,13 @@ systemd:
       [Unit]
       Description=Adds labels to the node after kubelet startup
       After=k8s-kubelet.service
-      Requires=k8s-kubelet.service
+      Wants=k8s-kubelet.service
       [Service]
       Type=oneshot
       RemainAfterExit=yes
       Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
       ExecStart=/bin/sh -c '\
-        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do sleep 1 && echo "Waiting for healthy k8s";done;sleep 30s; \
+        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         $KUBECTL label nodes --overwrite $(hostname) node-role.kubernetes.io/worker=""; \
         $KUBECTL label nodes --overwrite $(hostname) kubernetes.io/role=worker'
       [Install]

--- a/v_5_0_0/worker_template.go
+++ b/v_5_0_0/worker_template.go
@@ -203,7 +203,6 @@ systemd:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      TimeoutStartSec=1200
       Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
       ExecStart=/bin/sh -c '\
         while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do sleep 1 && echo "Waiting for healthy k8s";done;sleep 30s; \


### PR DESCRIPTION
This makes the labeling service more resistant to the kubelet having a rough start which seems to happen on `azure`. Now all nodes get labeled correctly:
```
k get nodes   
NAME                  STATUS   ROLES    AGE     VERSION
9g6ci-master-000000   Ready    master   7m56s   v1.16.3
9g6ci-worker-000000   Ready    worker   2m      v1.16.3
9g6ci-worker-000001   Ready    worker   115s    v1.16.3
9g6ci-worker-000002   Ready    worker   114s    v1.16.3
```
