### PR TITLE
Revert master role taint

### DIFF
--- a/v_5_0_0/master_template.go
+++ b/v_5_0_0/master_template.go
@@ -290,7 +290,7 @@ systemd:
         --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
         --network-plugin=cni \
         --register-node=true \
-        --register-with-taints=node.kubernetes.io/master=:NoSchedule \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
         --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
         --node-labels="node.kubernetes.io/master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
         --v=2


### PR DESCRIPTION
cluster-autoscaler has a toleration on `node-role.kubernetes.io/master`. Since this taint/toleration isn't actually related to the 1.16 role label changes, I am reverting `--register-with-taints` to its original value (changed here https://github.com/giantswarm/k8scloudconfig/commit/d462f8eadb3adacc49195758d47a47de57c96420#diff-7dc3f634c8bce58559a71d4cd5203f7fL293).