### PR TITLE
Add longer timeout and retries for wget operation in debug-tools

### DIFF
--- a/v_5_0_0/files/conf/install-debug-tools
+++ b/v_5_0_0/files/conf/install-debug-tools
@@ -5,13 +5,13 @@ mkdir -p /opt/bin
 
 # download calicoctl
 CALICOCTL_VERSION=v3.10.1
-wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
+wget --timeout=600 --no-dns-cache --retry-connrefused https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
 mv calicoctl-linux-amd64 /opt/bin/calicoctl
 chmod +x /opt/bin/calicoctl
 
 # download crictl
 CRICTL_VERSION=v1.16.1
-wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+wget --timeout=600 --no-dns-cache --retry-connrefused https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 tar xvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 mv crictl /opt/bin/crictl
 chmod +x /opt/bin/crictl


### PR DESCRIPTION
We see these units fail quite recently. This should help with failures in the unit.

This does not affect much, but having the failed unit causes alerts.