### PR TITLE
Revert master role taint for calico-kube-controllers

### DIFF
--- a/v_5_0_0/files/k8s-resource/calico-all.yaml
+++ b/v_5_0_0/files/k8s-resource/calico-all.yaml
@@ -563,7 +563,7 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node.kubernetes.io/master
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
`calico-kube-controllers` doesn't get scheduled in release 11.0 clusters because I forgot to change its toleration in https://github.com/giantswarm/k8scloudconfig/pull/624. This PR corrects that.