### PR TITLE
Remove debug tools systemd unit

### DIFF
--- a/v_5_1_0/master_template.go
+++ b/v_5_1_0/master_template.go
@@ -349,18 +349,6 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
-  - name: debug-tools.service
-    enabled: true
-    contents: |
-      [Unit]
-      Description=Install calicoctl and crictl tools
-      After=network.target
-      [Service]
-      Type=oneshot
-      ExecStart=/opt/install-debug-tools
-      [Install]
-      WantedBy=multi-user.target
-
 storage:
   files:
     - path: /etc/ssh/trusted-user-ca-keys.pem


### PR DESCRIPTION
Script is still there to install manually - just not automatically everywhere.