### PR TITLE
Lowercase $(hostname) when matching k8s node name with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ version directory, and  then changes are introduced.
 
 ## [v5.1.0] - 2020-01-21
 
+- Lowercase $(hostname) to match k8s node name e.g. when using with kubectl.
+
 ## [v5.0.0] - 2020-01-02
 
 ### Changed

--- a/v_5_1_0/files/conf/k8s-addons
+++ b/v_5_1_0/files/conf/k8s-addons
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+export HOSTNAME=$(hostname | tr '[:upper:]' '[:lower:]')
 export KUBECONFIG=/etc/kubernetes/kubeconfig/addons.yaml
 export KUBECTL="/opt/bin/hyperkube kubectl"
 
 # wait for healthy master
-while [ "$($KUBECTL get nodes $(hostname) -o jsonpath='{.metadata.name}')" != "$(hostname)" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
+while [ "$($KUBECTL get nodes $HOSTNAME -o jsonpath='{.metadata.name}')" != "$HOSTNAME" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
 
 # label namespaces (required for network egress policies)
 NAMESPACES="default kube-system" 
@@ -41,7 +42,7 @@ do
 done
 
 # check for other master and remove it
-THIS_MACHINE=$(cat /etc/hostname)
+THIS_MACHINE=$HOSTNAME
 for master in $($KUBECTL get nodes --no-headers=true --selector role=master | awk '{print $1}')
 do
     if [ "$master" != "$THIS_MACHINE" ]; then

--- a/v_5_1_0/master_template.go
+++ b/v_5_1_0/master_template.go
@@ -329,9 +329,9 @@ systemd:
       RemainAfterExit=yes
       Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
       ExecStart=/bin/sh -c '\
-        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
-        $KUBECTL label nodes --overwrite $(hostname) node-role.kubernetes.io/master=""; \
-        $KUBECTL label nodes --overwrite $(hostname) kubernetes.io/role=master'
+        while [ "$($KUBECTL get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
+        $KUBECTL label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/master=""; \
+        $KUBECTL label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master'
       [Install]
       WantedBy=multi-user.target
   - name: k8s-addons.service

--- a/v_5_1_0/worker_template.go
+++ b/v_5_1_0/worker_template.go
@@ -205,9 +205,9 @@ systemd:
       RemainAfterExit=yes
       Environment="KUBECTL=/opt/bin/hyperkube kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml"
       ExecStart=/bin/sh -c '\
-        while [ "$($KUBECTL get nodes $(hostname)| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
-        $KUBECTL label nodes --overwrite $(hostname) node-role.kubernetes.io/worker=""; \
-        $KUBECTL label nodes --overwrite $(hostname) kubernetes.io/role=worker'
+        while [ "$($KUBECTL get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
+        $KUBECTL label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/worker=""; \
+        $KUBECTL label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=worker'
       [Install]
       WantedBy=multi-user.target
   - name: etcd2.service


### PR DESCRIPTION
Starting from release v_5_0_0 e.g. node labels were set by separate systemd
unit with kubectl and that must match running hostname with k8s node name.

That matching is case sensitive and since Azure sets hostname with uppercase
letters in Base36 encoding, the hostname must be convered to lowercase in order
to match k8s node name.