### PR TITLE
Avoid checking for domain validity of IP addresses

### DIFF
--- a/v_5_0_0/files/conf/wait-for-domains
+++ b/v_5_0_0/files/conf/wait-for-domains
@@ -2,10 +2,13 @@
 domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} {{ .RegistryDomain }}"
 
 for domain in $domains; do
-until nslookup $domain; do
-    echo "Waiting for domain $domain to be available"
-    sleep 5
-done
-
-echo "Successfully resolved domain $domain"
+  if [[ $domain =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    until nslookup $domain; do
+      echo "Waiting for domain $domain to be available"
+      sleep 5
+    done
+    echo "Successfully resolved domain $domain"
+  else
+    echo "$domain is an IP address, skipping domain check."
+  fi
 done

--- a/v_5_0_0/files/conf/wait-for-domains
+++ b/v_5_0_0/files/conf/wait-for-domains
@@ -2,13 +2,13 @@
 domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} {{ .RegistryDomain }}"
 
 for domain in $domains; do
-  if [[ $domain =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [ "$domain" == "127.0.0.1" ]; then
+    echo "Skipping domain check for $domain."
+  else
     until nslookup $domain; do
       echo "Waiting for domain $domain to be available"
       sleep 5
     done
     echo "Successfully resolved domain $domain"
-  else
-    echo "$domain is an IP address, skipping domain check."
   fi
 done


### PR DESCRIPTION
So the `wait-for-domains` service/script is used on a master node to wait for the DNS records to be ready before going on with the setup of the kubernetes control plane.
In azure, the script looked like this (for a long time):

```
#!/bin/bash
domains="127.0.0.1 api.yguz7.k8s.godsmack.westeurope.azure.gigantic.io quay.io"

for domain in $domains; do
until nslookup $domain; do
    echo "Waiting for domain $domain to be available"
    sleep 5
done

echo "Successfully resolved domain $domain"
done
```

At some point, `nslookup 127.0.0.1` started failing and the master node started not getting boostrapped correctly.

This PR adds a check to avoid checking the "DNS validity" for ip addresses.
Tested on a live cluster on azure and it works (cluster comes correctly up with this change).