### PR TITLE
Revert "Increase kubelet hard memory eviction (#635)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ version directory, and  then changes are introduced.
 
 - Lowercase $(hostname) to match k8s node name e.g. when using with kubectl.
 - Extend ignition with debug options.
-- Increase kubelet hard memory eviction from 200Mi to 400Mi.
 
 ## [v5.0.0] - 2020-01-02
 

--- a/v_5_1_0/files/config/kubelet-master.yaml.tmpl
+++ b/v_5_1_0/files/config/kubelet-master.yaml.tmpl
@@ -11,7 +11,7 @@ staticPodPath: /etc/kubernetes/manifests
 evictionSoft:
   memory.available: "500Mi"
 evictionHard:
-  memory.available: "400Mi"
+  memory.available: "200Mi"
   imagefs.available: "15%"
 evictionSoftGracePeriod:
   memory.available: "5s"

--- a/v_5_1_0/files/config/kubelet-worker.yaml.tmpl
+++ b/v_5_1_0/files/config/kubelet-worker.yaml.tmpl
@@ -10,7 +10,7 @@ clusterDomain: {{.Cluster.Kubernetes.Domain}}
 evictionSoft:
   memory.available: "500Mi"
 evictionHard:
-  memory.available: "400Mi"
+  memory.available: "200Mi"
   imagefs.available: "15%"
 evictionSoftGracePeriod:
   memory.available: "5s"


### PR DESCRIPTION
This reverts commit 0a6035168fd670351f1204ad3444ecf67b681cd0.

According to @sslavic's findings this change does not help to fix https://github.com/giantswarm/giantswarm/issues/8361 so reverting