### PR TITLE
Add reserved ephemeral port range to avoid conflicts with kube-apiserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ version directory, and  then changes are introduced.
 
 ## [v5.2.0] - Unreleased
 
+- Reserve ports `30000-32767` from ephemeral port range for `kube-apiserver` use.
+
 ## [v5.1.0] - 2020-01-21
 
 - Lowercase $(hostname) to match k8s node name e.g. when using with kubectl.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ k8scloudconfig library uses semver versioning scheme. Please follow simple rules
 1. Increment MAJOR version number when breaking library API changes introduced.
 2. Increment PATCH version number for critical bug fixes. Patch release needs to be immediately included into patch release of operator.
 3. Increment MINOR version number for all other changes.
-4. WIP releases are only possible for major and minor version updates. Patch releases should be immediately freezed.
+4. WIP releases are only possible for major and minor version updates. Patch releases should be immediately frozen.
 
 Examples:
 - "Hyperkube upgrade from 1.9.5 to 1.10.1" is a minor version upgrade.

--- a/v_5_2_0/files/conf/hardening.conf
+++ b/v_5_2_0/files/conf/hardening.conf
@@ -17,6 +17,8 @@ vm.max_map_count = 262144
 # See https://github.com/kubernetes/ingress-nginx/issues/1939
 net.core.somaxconn=32768
 net.ipv4.ip_local_port_range=1024 65535
+# Reserved to avoid conflicts with kube-apiserver, which allocates within this range
+net.ipv4.ip_local_reserved_ports=30000-32767
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.all.arp_ignore = 1
 net.ipv4.conf.all.arp_announce = 2


### PR DESCRIPTION
I messed up rebasing the last PR somehow. Here is the fix for https://github.com/giantswarm/giantswarm/issues/8798, this replaces https://github.com/giantswarm/k8scloudconfig/pull/638