### PR TITLE
v4.9.1: copy

### DIFF
--- a/v_4_9_1/cloudconfig.go
+++ b/v_4_9_1/cloudconfig.go
@@ -1,0 +1,103 @@
+package v_4_9_0
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"text/template"
+
+	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	defaultRegistryDomain            = "quay.io"
+	defaultImagePullProgressDeadline = "1m"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.15.5"
+	etcdImage                        = "giantswarm/etcd:v3.3.15"
+	etcdPort                         = 443
+)
+
+type CloudConfigConfig struct {
+	Params   Params
+	Template string
+}
+
+func DefaultCloudConfigConfig() CloudConfigConfig {
+	return CloudConfigConfig{
+		Params:   Params{},
+		Template: "",
+	}
+}
+
+func DefaultParams() Params {
+	return Params{
+		EtcdPort:       etcdPort,
+		RegistryDomain: defaultRegistryDomain,
+		Images: Images{
+			Kubernetes: kubernetesImage,
+			Etcd:       etcdImage,
+		},
+		ImagePullProgressDeadline: defaultImagePullProgressDeadline,
+	}
+}
+
+type CloudConfig struct {
+	config   string
+	params   Params
+	template string
+}
+
+func NewCloudConfig(config CloudConfigConfig) (*CloudConfig, error) {
+	if err := config.Params.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Params.%s", err)
+	}
+	if config.Template == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Template must not be empty")
+	}
+
+	c := &CloudConfig{
+		config:   "",
+		params:   config.Params,
+		template: config.Template,
+	}
+
+	return c, nil
+}
+
+func (c *CloudConfig) ExecuteTemplate() error {
+	tmpl, err := template.New("cloudconfig").Parse(c.template)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, c.params)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	ignitionJSON, err := ignition.ConvertTemplatetoJSON(buf.Bytes())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	c.config = string(ignitionJSON)
+
+	return nil
+}
+
+func (c *CloudConfig) Base64() string {
+	cloudConfigBytes := []byte(c.config)
+
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	w.Write(cloudConfigBytes)
+	w.Close()
+
+	return base64.StdEncoding.EncodeToString(b.Bytes())
+}
+
+func (c *CloudConfig) String() string {
+	return c.config
+}

--- a/v_4_9_1/cloudconfig_test.go
+++ b/v_4_9_1/cloudconfig_test.go
@@ -1,0 +1,86 @@
+package v_4_9_0
+
+import (
+	"encoding/base64"
+	"path"
+	"testing"
+
+	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+)
+
+func TestCloudConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		template         string
+		params           Params
+		customEtcdPort   int
+		expectedEtcdPort int
+	}{
+		{
+			name:             "master",
+			template:         MasterTemplate,
+			params:           DefaultParams(),
+			expectedEtcdPort: 443,
+		},
+		{
+			name:             "worker",
+			template:         WorkerTemplate,
+			params:           DefaultParams(),
+			expectedEtcdPort: 443,
+		},
+		{
+			name:             "worker",
+			template:         WorkerTemplate,
+			params:           DefaultParams(),
+			customEtcdPort:   2379,
+			expectedEtcdPort: 2379,
+		},
+	}
+
+	for _, tc := range tests {
+		c := DefaultCloudConfigConfig()
+
+		tc.params.Extension = nopExtension{}
+
+		if tc.customEtcdPort != 0 {
+			tc.params.EtcdPort = tc.customEtcdPort
+		}
+
+		packagePath, err := GetPackagePath()
+		if err != nil {
+			t.Errorf("failed to retrieve package path, %v:", err)
+		}
+		filesPath := path.Join(packagePath, version, filesDir)
+		files, err := RenderFiles(filesPath, tc.params)
+		if err != nil {
+			t.Errorf("failed to render ignition files, %v:", err)
+		}
+		tc.params.Files = files
+
+		c.Params = tc.params
+		c.Template = tc.template
+
+		cloudConfig, err := NewCloudConfig(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if cloudConfig.params.EtcdPort != tc.expectedEtcdPort {
+			t.Errorf("expected etcd port %q, got %q", tc.expectedEtcdPort, cloudConfig.params.EtcdPort)
+		}
+		if err := cloudConfig.ExecuteTemplate(); err != nil {
+			t.Fatal(err)
+		}
+
+		cloudConfigBase64 := cloudConfig.Base64()
+		if _, err := base64.StdEncoding.DecodeString(cloudConfigBase64); err != nil {
+			t.Errorf("The string isn't Base64 encoded: %v", err)
+		}
+
+		_, err = ignition.ConvertTemplatetoJSON([]byte(cloudConfig.String()))
+		if err != nil {
+			t.Fatalf("failed to validate ignition %#q config, %v:", tc.name, err)
+		}
+
+	}
+}

--- a/v_4_9_1/common_template_test.go
+++ b/v_4_9_1/common_template_test.go
@@ -1,0 +1,11 @@
+package v_4_9_0
+
+type nopWriter struct{}
+
+func (nopWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+type nopExtension struct{}
+
+func (nopExtension) Files() ([]FileAsset, error)         { return nil, nil }
+func (nopExtension) Units() ([]UnitAsset, error)         { return nil, nil }
+func (nopExtension) VerbatimSections() []VerbatimSection { return nil }

--- a/v_4_9_1/error.go
+++ b/v_4_9_1/error.go
@@ -1,0 +1,12 @@
+package v_4_9_0
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/v_4_9_1/filemanager.go
+++ b/v_4_9_1/filemanager.go
@@ -1,0 +1,73 @@
+package v_4_9_0
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"runtime"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	version  = "v_4_9_0"
+	filesDir = "files"
+)
+
+// Files is map[string]string (k: filename, v: contents) for files that are fetched from disk
+// and then filled with data.
+type Files map[string]string
+
+// RenderFiles walks over filesdir and parses all regular files with
+// text/template. Parsed templates are then rendered with ctx, base64 encoded
+// and added to returned Files.
+//
+// filesdir must not contain any other files than templates that can be parsed
+// with text/template.
+func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
+	files := Files{}
+
+	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if f.Mode().IsRegular() {
+			tmpl, err := template.ParseFiles(path)
+			if err != nil {
+				return microerror.Maskf(err, "failed to parse file %#q", path)
+			}
+			var data bytes.Buffer
+			tmpl.Execute(&data, ctx)
+
+			relativePath, err := filepath.Rel(filesdir, path)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			files[relativePath] = base64.StdEncoding.EncodeToString(data.Bytes())
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return files, nil
+}
+
+// GetIgnitionPath returns path for the ignition assets based on
+// base ignition directory and package subdirectory with assets.
+func GetIgnitionPath(ignitionDir string) string {
+	return filepath.Join(ignitionDir, version, filesDir)
+}
+
+// GetPackagePath returns top package path for the current runtime file.
+// For example, for /go/src/k8scloudconfig/v_4_1_0/file.go function
+// returns /go/src/k8scloudconfig.
+// This function used only in tests for retrieving ignition assets in runtime.
+func GetPackagePath() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", microerror.New("failed to retrieve runtime information")
+	}
+
+	return filepath.Dir(filepath.Dir(filename)), nil
+}

--- a/v_4_9_1/filemanager_test.go
+++ b/v_4_9_1/filemanager_test.go
@@ -1,0 +1,90 @@
+package v_4_9_0
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testFilesDir           = "testfiles"
+	testConfigDir          = "config"
+	testConfigFile         = "config.yaml"
+	testConfigFileTemplate = `foo: {{.Foo}}`
+)
+
+type RenderParams struct {
+	Foo   string
+	Files Files
+}
+
+func Test_RenderFiles(t *testing.T) {
+
+	// Prepare temporary files structure
+	filesDir, err := ioutil.TempDir("", testFilesDir)
+	if err != nil {
+		t.Fatalf("failed to create temporary directory, %v:", err)
+	}
+	defer os.RemoveAll(filesDir)
+
+	configPath := path.Join(filesDir, testConfigDir)
+	err = os.Mkdir(configPath, 0777)
+	if err != nil {
+		t.Fatalf("failed to create config directory, %v:", err)
+	}
+
+	tmpfile, err := os.Create(path.Join(configPath, testConfigFile))
+	if err != nil {
+		t.Fatalf("failed to create temporary config file, %v:", err)
+	}
+
+	contentBytes := []byte(testConfigFileTemplate)
+	if _, err := tmpfile.Write(contentBytes); err != nil {
+		t.Fatalf("failed to write template content into temporary file, %v:", err)
+	}
+
+	tests := []struct {
+		fileContent     string
+		filesDir        string
+		configDir       string
+		configFile      string
+		params          RenderParams
+		expectedContent string
+	}{
+		{
+			fileContent: testTemplate,
+			filesDir:    filesDir,
+			configDir:   testConfigDir,
+			configFile:  testConfigFile,
+			params:      RenderParams{Foo: "bar"},
+			// base64 encoded `foo: bar` string
+			expectedContent: "Zm9vOiBiYXI=",
+		},
+	}
+
+	for _, tc := range tests {
+		files, err := RenderFiles(tc.filesDir, tc.params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tc.params.Files = files
+		contentTemplate := fmt.Sprintf("{{  index .Files \"%s/%s\" }}", tc.configDir, tc.configFile)
+		tmpl, err := template.New("").Parse(contentTemplate)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf := new(bytes.Buffer)
+		if err := tmpl.Execute(buf, tc.params); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, tc.expectedContent, buf.String(), "content should be equal")
+	}
+}

--- a/v_4_9_1/files/conf/10-docker.rules
+++ b/v_4_9_1/files/conf/10-docker.rules
@@ -1,0 +1,8 @@
+-w /usr/bin/docker -k docker
+-w /var/lib/docker -k docker
+-w /etc/docker -k docker
+-w /etc/systemd/system/docker.service.d/10-giantswarm-extra-args.conf -k docker
+-w /etc/systemd/system/docker.service.d/01-wait-docker.conf -k docker
+-w /usr/lib/systemd/system/docker.service -k docker
+-w /usr/lib/systemd/system/docker.socket -k docker
+

--- a/v_4_9_1/files/conf/calicoctl.cfg
+++ b/v_4_9_1/files/conf/calicoctl.cfg
@@ -1,0 +1,8 @@
+apiVersion: projectcalico.org/v3
+kind: CalicoAPIConfig
+metadata:
+spec:
+  etcdEndpoints: https://{{.Cluster.Etcd.Domain}}:{{ .EtcdPort }}
+  etcdKeyFile: /etc/kubernetes/ssl/etcd/server-key.pem
+  etcdCertFile: /etc/kubernetes/ssl/etcd/server-crt.pem
+  etcdCACertFile: /etc/kubernetes/ssl/etcd/server-ca.pem

--- a/v_4_9_1/files/conf/crictl
+++ b/v_4_9_1/files/conf/crictl
@@ -1,0 +1,4 @@
+runtime-endpoint: unix:///var/run/dockershim/dockershim.sock
+image-endpoint: unix:///var/run/dockershim/dockershim.sock
+timeout: 10
+debug: false

--- a/v_4_9_1/files/conf/etcd-alias
+++ b/v_4_9_1/files/conf/etcd-alias
@@ -1,0 +1,6 @@
+alias etcdctl="ETCDCTL_API=3 \
+    ETCDCTL_ENDPOINTS=https://{{.Cluster.Etcd.Domain}}:{{ .EtcdPort }} \
+    ETCDCTL_CACERT=/etc/kubernetes/ssl/etcd/client-ca.pem \
+    ETCDCTL_CERT=/etc/kubernetes/ssl/etcd/client-crt.pem \
+    ETCDCTL_KEY=/etc/kubernetes/ssl/etcd/client-key.pem \
+    etcdctl"

--- a/v_4_9_1/files/conf/hardening.conf
+++ b/v_4_9_1/files/conf/hardening.conf
@@ -1,0 +1,19 @@
+fs.inotify.max_user_watches = 16384
+kernel.kptr_restrict = 2
+kernel.sysrq = 0
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.default.log_martians = 1
+net.ipv4.tcp_timestamps = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+# Increased mmapfs because some applications, like ES, need higher limit to store data properly
+vm.max_map_count = 262144
+# Ingress controller performance improvements
+# See https://github.com/kubernetes/ingress-nginx/issues/1939
+net.core.somaxconn=32768
+net.ipv4.ip_local_port_range=1024 65535
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.all.arp_ignore = 1
+net.ipv4.conf.all.arp_announce = 2

--- a/v_4_9_1/files/conf/install-debug-tools
+++ b/v_4_9_1/files/conf/install-debug-tools
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+mkdir -p /opt/bin
+
+# download calicoctl
+CALICOCTL_VERSION=v3.9.1
+wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl-linux-amd64
+mv calicoctl-linux-amd64 /opt/bin/calicoctl
+chmod +x /opt/bin/calicoctl
+
+# download crictl
+CRICTL_VERSION=v1.15.0
+wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+tar xvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+mv crictl /opt/bin/crictl
+chmod +x /opt/bin/crictl
+rm crictl-${CRICTL_VERSION}-linux-amd64.tar.gz

--- a/v_4_9_1/files/conf/ip_vs.conf
+++ b/v_4_9_1/files/conf/ip_vs.conf
@@ -1,0 +1,5 @@
+ip_vs
+ip_vs_rr
+ip_vs_wrr
+ip_vs_sh
+nf_conntrack_ipv4

--- a/v_4_9_1/files/conf/k8s-addons
+++ b/v_4_9_1/files/conf/k8s-addons
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+export KUBECONFIG=/etc/kubernetes/kubeconfig/addons.yaml
+# kubectl 1.12.2
+KUBECTL={{ .RegistryDomain }}/giantswarm/docker-kubectl:f5cae44c480bd797dc770dd5f62d40b74063c0d7
+
+/usr/bin/docker pull $KUBECTL
+
+# wait for healthy master
+while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
+
+# label namespaces (required for network egress policies)
+NAMESPACES="default kube-system" 
+for namespace in ${NAMESPACES}
+do
+    if ! /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get namespaces -l name=${namespace} | grep ${namespace}; then
+        while
+            /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL label namespace ${namespace} name=${namespace}
+            [ "$?" -ne "0" ]
+        do
+            echo "failed to label namespace ${namespace}, retrying in 5 sec"
+            sleep 5s
+        done
+    fi
+done
+
+# apply Security bootstrap (RBAC and PSP)
+SECURITY_FILES=""
+SECURITY_FILES="${SECURITY_FILES} rbac_bindings.yaml"
+SECURITY_FILES="${SECURITY_FILES} rbac_roles.yaml"
+SECURITY_FILES="${SECURITY_FILES} psp_policies.yaml"
+SECURITY_FILES="${SECURITY_FILES} psp_roles.yaml"
+SECURITY_FILES="${SECURITY_FILES} psp_binding.yaml"
+
+for manifest in $SECURITY_FILES
+do
+    while
+        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+        [ "$?" -ne "0" ]
+    do
+        echo "failed to apply /srv/$manifest, retrying in 5 sec"
+        sleep 5s
+    done
+done
+
+# check for other master and remove it
+THIS_MACHINE=$(cat /etc/hostname)
+for master in $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get nodes --no-headers=true --selector role=master | awk '{print $1}')
+do
+    if [ "$master" != "$THIS_MACHINE" ]; then
+        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL delete node $master
+    fi
+done
+
+# wait for etcd dns (return code 35 is bad certificate which is good enough here)
+while
+    curl "https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }}" -k 2>/dev/null >/dev/null
+    RET_CODE=$?
+    [ "$RET_CODE" -ne "35" ]
+do
+    echo "Waiting for etcd to be ready . . "
+    sleep 3s
+done
+
+# create kube-proxy configmap
+while
+    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv $KUBECTL create configmap kube-proxy --from-file=kube-proxy.yaml=/srv/kube-proxy-config.yaml -o yaml --dry-run \
+    | /usr/bin/docker run  -i --log-driver=none -a stdin -a stdout -a stderr -e KUBECONFIG=${KUBECONFIG} -v /etc/kubernetes:/etc/kubernetes --net=host --rm $KUBECTL apply -n kube-system -f -
+    [ "$?" -ne "0" ]
+do
+    echo "failed to configure kube-proxy from /srv/kube-proxy-config.yaml, retrying in 5 sec"
+    sleep 5s
+done
+
+# install kube-proxy
+PROXY_MANIFESTS="kube-proxy-sa.yaml kube-proxy-ds.yaml"
+for manifest in $PROXY_MANIFESTS
+do
+    while
+        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+        [ "$?" -ne "0" ]
+    do
+        echo "failed to apply /srv/$manifest, retrying in 5 sec"
+        sleep 5s
+    done
+done
+echo "kube-proxy successfully installed"
+
+# restart ds to apply config from configmap
+/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL delete pods -l k8s-app=kube-proxy -n kube-system
+
+{{ if not .DisableCalico -}}
+
+# apply calico
+CALICO_FILE="calico-all.yaml"
+
+while
+    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$CALICO_FILE
+    [ "$?" -ne "0" ]
+do
+    echo "failed to apply /srv/$manifest, retrying in 5 sec"
+    sleep 5s
+done
+
+# wait for healthy calico - we check for pods - desired vs ready
+while
+    # result of this is 'eval [ "$DESIRED_POD_COUNT" -eq "$READY_POD_COUNT" ]'
+    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system  get ds calico-node 2>/dev/null >/dev/null
+    RET_CODE_1=$?
+    eval $(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system get ds calico-node | tail -1 | awk '{print "[ \"" $2"\" -eq \""$4"\" ] "}')
+    RET_CODE_2=$?
+    [ "$RET_CODE_1" -ne "0" ] || [ "$RET_CODE_2" -ne "0" ]
+do
+    echo "Waiting for calico to be ready . . "
+    sleep 3s
+done
+
+{{ end -}}
+
+# apply default storage class
+if [ -f /srv/default-storage-class.yaml ]; then
+    while
+        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/default-storage-class.yaml
+        [ "$?" -ne "0" ]
+    do
+        echo "failed to apply /srv/default-storage-class.yaml, retrying in 5 sec"
+        sleep 5s
+    done
+else
+    echo "no default storage class to apply"
+fi
+
+# apply priority classes:
+PRIORITY_CLASSES_FILE="priority_classes.yaml"
+
+while
+    /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$PRIORITY_CLASSES_FILE
+    [ "$?" -ne "0" ]
+do
+    echo "failed to apply /srv/$PRIORITY_CLASSES_FILE, retrying in 5 sec"
+    sleep 5s
+done
+
+# apply k8s addons
+MANIFESTS=""
+{{ range .ExtraManifests -}}
+MANIFESTS="${MANIFESTS} {{ . }}"
+{{ end -}}
+{{ if not .DisableIngressControllerService -}}
+MANIFESTS="${MANIFESTS} ingress-controller-svc.yaml"
+{{ end -}}
+
+for manifest in $MANIFESTS
+do
+    while
+        /usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /srv:/srv -v /etc/kubernetes:/etc/kubernetes $KUBECTL apply -f /srv/$manifest
+        [ "$?" -ne "0" ]
+    do
+        echo "failed to apply /srv/$manifest, retrying in 5 sec"
+        sleep 5s
+    done
+done
+echo "Addons successfully installed"

--- a/v_4_9_1/files/conf/sshd_config
+++ b/v_4_9_1/files/conf/sshd_config
@@ -1,0 +1,15 @@
+# Use most defaults for sshd configuration.
+Subsystem sftp internal-sftp
+ClientAliveInterval 180
+UseDNS no
+UsePAM yes
+PrintLastLog no # handled by PAM
+PrintMotd no # handled by PAM
+# Non defaults (#100)
+ClientAliveCountMax 2
+PasswordAuthentication no
+TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
+MaxAuthTries 5
+LoginGraceTime 60
+AllowTcpForwarding no
+AllowAgentForwarding no

--- a/v_4_9_1/files/conf/trusted-user-ca-keys.pem
+++ b/v_4_9_1/files/conf/trusted-user-ca-keys.pem
@@ -1,0 +1,1 @@
+{{ .SSOPublicKey }}

--- a/v_4_9_1/files/conf/wait-for-domains
+++ b/v_4_9_1/files/conf/wait-for-domains
@@ -1,0 +1,11 @@
+#!/bin/bash
+domains="{{.Cluster.Etcd.Domain}} {{.Cluster.Kubernetes.API.Domain}} quay.io"
+
+for domain in $domains; do
+until nslookup $domain; do
+    echo "Waiting for domain $domain to be available"
+    sleep 5
+done
+
+echo "Successfully resolved domain $domain"
+done

--- a/v_4_9_1/files/config/kube-proxy.yaml
+++ b/v_4_9_1/files/config/kube-proxy.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+clientConnection:
+  kubeconfig: /etc/kubernetes/config/proxy-kubeconfig.yaml
+kind: KubeProxyConfiguration
+mode: iptables
+resourceContainer: /kube-proxy
+clusterCIDR: {{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}
+metricsBindAddress: 0.0.0.0:10249

--- a/v_4_9_1/files/config/kubelet-master.yaml.tmpl
+++ b/v_4_9_1/files/config/kubelet-master.yaml.tmpl
@@ -1,0 +1,35 @@
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+address: ${DEFAULT_IPV4}
+port: 10250
+healthzBindAddress: ${DEFAULT_IPV4}
+healthzPort: 10248
+clusterDNS:
+  - {{.Cluster.Kubernetes.DNS.IP}}
+clusterDomain: {{.Cluster.Kubernetes.Domain}}
+staticPodPath: /etc/kubernetes/manifests
+evictionSoft:
+  memory.available: "500Mi"
+evictionHard:
+  memory.available: "200Mi"
+evictionSoftGracePeriod:
+  memory.available: "5s"
+evictionMaxPodGracePeriod: 60
+kubeReserved:
+  cpu: 350m
+  memory: 1280Mi
+  ephemeral-storage: 1024Mi
+kubeReservedCgroup: /kubereserved.slice
+kubeletCgroups: /kubereserved.slice
+runtimeCgroups: /kubereserved.slice
+systemReserved:
+  cpu: 250m
+  memory: 384Mi
+systemReservedCgroup: /system.slice
+authentication:
+  anonymous:
+    enabled: true # Defaults to false as of 1.10
+  webhook:
+    enabled: false # Deafults to true as of 1.10
+authorization:
+  mode: AlwaysAllow # Deafults to webhook as of 1.10

--- a/v_4_9_1/files/config/kubelet-worker.yaml.tmpl
+++ b/v_4_9_1/files/config/kubelet-worker.yaml.tmpl
@@ -1,0 +1,34 @@
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+address: ${DEFAULT_IPV4}
+port: 10250
+healthzBindAddress: ${DEFAULT_IPV4}
+healthzPort: 10248
+clusterDNS:
+  - {{.Cluster.Kubernetes.DNS.IP}}
+clusterDomain: {{.Cluster.Kubernetes.Domain}}
+evictionSoft:
+  memory.available: "500Mi"
+evictionHard:
+  memory.available: "200Mi"
+evictionSoftGracePeriod:
+  memory.available: "5s"
+evictionMaxPodGracePeriod: 60
+kubeReserved:
+  cpu: 250m
+  memory: 768Mi
+  ephemeral-storage: 1024Mi
+kubeReservedCgroup: /kubereserved.slice
+kubeletCgroups: /kubereserved.slice
+runtimeCgroups: /kubereserved.slice
+systemReserved:
+  cpu: 250m
+  memory: 384Mi
+systemReservedCgroup: /system.slice
+authentication:
+  anonymous:
+    enabled: true # Defaults to false as of 1.10
+  webhook:
+    enabled: false # Deafults to true as of 1.10
+authorization:
+  mode: AlwaysAllow # Deafults to webhook as of 1.10

--- a/v_4_9_1/files/config/scheduler.yaml
+++ b/v_4_9_1/files/config/scheduler.yaml
@@ -1,0 +1,8 @@
+kind: KubeSchedulerConfiguration
+algorithmSource:
+  provider: DefaultProvider
+apiVersion: kubescheduler.config.k8s.io/v1alpha1
+clientConnection:
+  kubeconfig: /etc/kubernetes/kubeconfig/scheduler.yaml
+failureDomains: kubernetes.io/hostname,failure-domain.beta.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region
+hardPodAffinitySymmetricWeight: 1

--- a/v_4_9_1/files/k8s-resource/calico-all.yaml
+++ b/v_4_9_1/files/k8s-resource/calico-all.yaml
@@ -1,0 +1,826 @@
+# CALICO HAS SEPARATE MANIFEST FOR AZURE
+# the azure manifest can be found in: https://github.com/giantswarm/azure-operator/blob/master/service/controller/vX/cloudconfig/template.go
+# where X is the version of azure operator
+#
+# Extra changes:
+#  - Added resource limits to calico-node and calico-kube-controller.
+#  - Added resource limits to install-cni.
+#  - Added 'priorityClassName: system-cluster-critical' to calico daemonset.
+#
+# Calico Version v3.9.1
+# https://docs.projectcalico.org/v3.9/release-notes/
+# This manifest includes the following component versions:
+#   calico/node:v3.9.1
+#   calico/cni:v3.9.1
+#   calico/kube-controllers:v3.9.1
+
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # Configure this with the location of your etcd cluster.
+  etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }}"
+
+  # If you're using TLS enabled etcd uncomment the following.
+  # You must also populate the Secret below with these files.
+  etcd_ca: "/calico-secrets/client-ca.pem"
+  etcd_cert: "/calico-secrets/client-crt.pem"
+  etcd_key: "/calico-secrets/client-key.pem"
+  # Typha is disabled.
+  typha_service_name: "none"
+  # Configure the backend to use.
+  calico_backend: "bird"
+
+  # Configure the MTU to use
+  veth_mtu: "{{.Cluster.Calico.MTU}}"
+
+  # The CNI network configuration to install on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          "etcd_key_file": "__ETCD_KEY_FILE__",
+          "etcd_cert_file": "__ETCD_CERT_FILE__",
+          "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+   name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMHandle
+    plural: ipamhandles
+    singular: ipamhandle
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMConfig
+    plural: ipamconfigs
+    singular: ipamconfig
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
+
+---
+# This manifest installs the calico-node container, as well
+# as the CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    giantswarm.io/service-type: managed
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+        giantswarm.io/service-type: managed
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      priorityClassName: system-cluster-critical
+      initContainers:
+        # This container installs the CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: {{ .RegistryDomain }}/giantswarm/cni:v3.9.1
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      containers:
+        # Runs calico-node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: {{ .RegistryDomain }}/giantswarm/node:v3.9.1
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "Warning"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+              memory: 150Mi
+          livenessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-live
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - /bin/calico-node
+                - -felix-ready
+                - -bird-ready
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      volumes:
+        # Used by calico-node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Mount in the etcd TLS secrets.
+        # See https://kubernetes.io/docs/concepts/configuration/secret/
+        - name: etcd-certs
+          hostPath:
+            path: /etc/kubernetes/ssl/etcd
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+
+---
+# This manifest deploys the Calico Kubernetes controllers.
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    giantswarm.io/service-type: managed
+    k8s-app: calico-kube-controllers
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+        giantswarm.io/service-type: managed
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/role: master
+      # The controllers must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: calico-kube-controllers
+          image: {{ .RegistryDomain }}/giantswarm/kube-controllers:v3.9.1
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node,serviceaccount
+          volumeMounts:
+            # Mount in the etcd TLS secrets.
+            - mountPath: /calico-secrets
+              name: etcd-certs
+          resources:
+            requests:
+              cpu: 250m
+              memory: 100Mi
+            limits:
+              cpu: 250m
+              memory: 100Mi
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/check-status
+                - -r
+      volumes:
+        # Mount in the etcd TLS secrets with mode 400.
+        # See https://kubernetes.io/docs/concepts/configuration/secret/
+        - name: etcd-certs
+          hostPath:
+            path: /etc/kubernetes/ssl/etcd
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+---
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - namespaces
+  - serviceaccounts
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  # IPAM resources are manipulated when nodes are deleted.
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - ippools
+  verbs:
+  - list
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - blockaffinities
+  - ipamblocks
+  - ipamhandles
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - crd.projectcalico.org
+  resources:
+  - clusterinformations
+  verbs:
+  - get
+  - create
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+  - kind: ServiceAccount
+    name: calico-kube-controllers
+    namespace: kube-system
+---
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-node
+rules:
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+      # Used to discover Typhas.
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  # Used by Calico for policy information.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # The CNI plugin patches pods/status.
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  # Calico monitors various CRDs for config.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+    verbs:
+      - get
+      - list
+      - watch
+  # Calico must create and update some CRDs on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+    verbs:
+      - create
+      - update
+  # Calico stores some configuration information on the node.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  # These permissions are only requried for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+  - kind: ServiceAccount
+    name: calico-node
+    namespace: kube-system

--- a/v_4_9_1/files/k8s-resource/ingress-controller-svc.yaml
+++ b/v_4_9_1/files/k8s-resource/ingress-controller-svc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "10254"
+    prometheus.io/scrape: "true"
+  name: nginx-ingress-controller
+  namespace: kube-system
+  labels:
+    k8s-app: nginx-ingress-controller
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    nodePort: 30010
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    nodePort: 30011
+    protocol: TCP
+    targetPort: 443
+  selector:
+    k8s-app: nginx-ingress-controller

--- a/v_4_9_1/files/k8s-resource/k8s-encryption-config.yaml
+++ b/v_4_9_1/files/k8s-resource/k8s-encryption-config.yaml
@@ -1,0 +1,11 @@
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: {{ .APIServerEncryptionKey }}
+    - identity: {}

--- a/v_4_9_1/files/k8s-resource/kube-proxy-ds.yaml
+++ b/v_4_9_1/files/k8s-resource/kube-proxy-ds.yaml
@@ -1,0 +1,86 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    component: kube-proxy
+    k8s-app: kube-proxy
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        component: kube-proxy
+        k8s-app: kube-proxy
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      # Mark the pod as a critical add-on for rescheduling.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # Make sure the pod gets scheduled on all nodes.
+      - operator: Exists
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      serviceAccountName: kube-proxy
+      containers:
+        - name: kube-proxy
+          image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
+          command:
+          - /hyperkube
+          - kube-proxy
+          - --config=/etc/kubernetes/config/proxy-config.yml
+          - --v=2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10256
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          resources:
+            requests:
+              memory: "80Mi"
+              cpu: "75m"
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+          - mountPath: /etc/kubernetes/config/
+            name: k8s-config
+          - mountPath: /etc/kubernetes/kubeconfig/
+            name: k8s-kubeconfig
+            readOnly: true
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+            readOnly: true
+          - mountPath: /lib/modules
+            name: lib-modules
+            readOnly: true
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/config/
+        name: k8s-config
+      - hostPath:
+          path: /etc/kubernetes/config/
+        name: k8s-kubeconfig
+      - hostPath:
+          path: /etc/kubernetes/ssl
+        name: ssl-certs-kubernetes
+      - hostPath:
+          path: /usr/share/ca-certificates
+        name: ssl-certs-host
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules

--- a/v_4_9_1/files/k8s-resource/kube-proxy-sa.yaml
+++ b/v_4_9_1/files/k8s-resource/kube-proxy-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-proxy
+  namespace: kube-system

--- a/v_4_9_1/files/k8s-resource/priority_classes.yaml
+++ b/v_4_9_1/files/k8s-resource/priority_classes.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: giantswarm-critical
+value: 1000000000
+globalDefault: false
+description: "This priority class is used by giantswarm kubernetes components."

--- a/v_4_9_1/files/k8s-resource/psp_bindings.yaml
+++ b/v_4_9_1/files/k8s-resource/psp_bindings.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: privileged-psp-users
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+- kind: ServiceAccount
+  name: kube-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp-user
+---
+# grants the restricted PSP role to
+# the all authenticated users.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: restricted-psp-users
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-psp-user

--- a/v_4_9_1/files/k8s-resource/psp_policies.yaml
+++ b/v_4_9_1/files/k8s-resource/psp_policies.yaml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65536
+---
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'secret'
+  - 'configMap'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  readOnlyRootFilesystem: false

--- a/v_4_9_1/files/k8s-resource/psp_roles.yaml
+++ b/v_4_9_1/files/k8s-resource/psp_roles.yaml
@@ -1,0 +1,31 @@
+# restrictedPSP grants access to use
+# the restricted PSP.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: restricted-psp-user
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - restricted
+  verbs:
+  - use
+---
+# privilegedPSP grants access to use the privileged
+# PSP.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: privileged-psp-user
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - privileged
+  verbs:
+  - use

--- a/v_4_9_1/files/k8s-resource/rbac_bindings.yaml
+++ b/v_4_9_1/files/k8s-resource/rbac_bindings.yaml
@@ -1,0 +1,95 @@
+## User
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: giantswarm-admin
+subjects:
+- kind: User
+  name: {{.Cluster.Kubernetes.API.Domain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+## Worker
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubelet
+subjects:
+- kind: User
+  name: {{.Cluster.Kubernetes.Kubelet.Domain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: proxy
+subjects:
+- kind: User
+  name: {{.Cluster.Kubernetes.Kubelet.Domain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:node-proxier
+  apiGroup: rbac.authorization.k8s.io
+---
+## Master
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-controller-manager
+subjects:
+- kind: User
+  name: {{.Cluster.Kubernetes.API.Domain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:kube-controller-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-scheduler
+subjects:
+- kind: User
+  name: {{.Cluster.Kubernetes.API.Domain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+## node-operator
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-operator
+subjects:
+- kind: User
+  name: node-operator.{{.BaseDomain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: node-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+## prometheus-external is prometheus from host cluster
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-external
+subjects:
+- kind: User
+  name: prometheus.{{.BaseDomain}}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: prometheus-external
+  apiGroup: rbac.authorization.k8s.io

--- a/v_4_9_1/files/k8s-resource/rbac_roles.yaml
+++ b/v_4_9_1/files/k8s-resource/rbac_roles.yaml
@@ -1,0 +1,34 @@
+## node-operator
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-operator
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+---
+## prometheus-external
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-external
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/v_4_9_1/files/kubeconfig/addons.yaml
+++ b/v_4_9_1/files/kubeconfig/addons.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: proxy
+  user:
+    client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+    client-key: /etc/kubernetes/ssl/apiserver-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: proxy
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/kubeconfig/controller-manager.yaml
+++ b/v_4_9_1/files/kubeconfig/controller-manager.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: controller-manager
+  user:
+    client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+    client-key: /etc/kubernetes/ssl/apiserver-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: controller-manager
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/kubeconfig/kube-proxy-master.yaml
+++ b/v_4_9_1/files/kubeconfig/kube-proxy-master.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: proxy
+  user:
+    client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+    client-key: /etc/kubernetes/ssl/apiserver-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: proxy
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/kubeconfig/kube-proxy-worker.yaml
+++ b/v_4_9_1/files/kubeconfig/kube-proxy-worker.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: proxy
+  user:
+    client-certificate: /etc/kubernetes/ssl/worker-crt.pem
+    client-key: /etc/kubernetes/ssl/worker-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/worker-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: proxy
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/kubeconfig/kubelet-master.yaml
+++ b/v_4_9_1/files/kubeconfig/kubelet-master.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: kubelet
+  user:
+    client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+    client-key: /etc/kubernetes/ssl/apiserver-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/kubeconfig/kubelet-worker.yaml
+++ b/v_4_9_1/files/kubeconfig/kubelet-worker.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: kubelet
+  user:
+    client-certificate: /etc/kubernetes/ssl/worker-crt.pem
+    client-key: /etc/kubernetes/ssl/worker-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/worker-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/kubeconfig/scheduler.yaml
+++ b/v_4_9_1/files/kubeconfig/scheduler.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+users:
+- name: scheduler
+  user:
+    client-certificate: /etc/kubernetes/ssl/apiserver-crt.pem
+    client-key: /etc/kubernetes/ssl/apiserver-key.pem
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+    server: https://{{.Cluster.Kubernetes.API.Domain}}
+contexts:
+- context:
+    cluster: local
+    user: scheduler
+  name: service-account-context
+current-context: service-account-context

--- a/v_4_9_1/files/manifests/k8s-api-healthz.yaml
+++ b/v_4_9_1/files/manifests/k8s-api-healthz.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s-api-healthz
+  namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  containers:
+    - name: k8s-api-healthz
+      env:
+      - name: HOST_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      command:
+        - /k8s-api-healthz
+        - --api-endpoint="https://$(HOST_IP):443/healthz"
+      image: quay.io/giantswarm/k8s-api-healthz:1c0cdf1ed5ee18fdf59063ecdd84bf3787f80fac
+      resources:
+        requests:
+          cpu: 50m
+          memory: 20Mi
+      volumeMounts:
+      - mountPath: /etc/kubernetes/ssl/
+        name: ssl-certs-kubernetes
+        readOnly: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes

--- a/v_4_9_1/files/manifests/k8s-api-server.yaml
+++ b/v_4_9_1/files/manifests/k8s-api-server.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s-api-server
+  namespace: kube-system
+  labels:
+    k8s-app: api-server
+    tier: control-plane
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  containers:
+  - name: k8s-api-server
+    image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
+    env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    command:
+    - /hyperkube
+    - kube-apiserver
+    {{ range .Hyperkube.Apiserver.Pod.CommandExtraArgs -}}
+    - {{ . }}
+    {{ end -}}
+    - --allow-privileged=true
+    - --anonymous-auth=false
+    - --insecure-port=0
+    - --kubelet-https=true
+    - --kubelet-preferred-address-types=InternalIP
+    - --secure-port={{.Cluster.Kubernetes.API.SecurePort}}
+    - --bind-address=0.0.0.0
+    - --etcd-prefix={{.Cluster.Etcd.Prefix}}
+    - --profiling=false
+    - --service-account-lookup=true
+    - --authorization-mode=RBAC
+    - --feature-gates=TTLAfterFinished=true
+    - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+    - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
+    - --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}}
+    - --etcd-servers=https://127.0.0.1:2379
+    - --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem
+    - --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem
+    - --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem
+    - --advertise-address=$(HOST_IP)
+    - --runtime-config=api/all=true,scheduling.k8s.io/v1alpha1=true
+    - --logtostderr=true
+    - --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
+    - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
+    - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
+    - --audit-log-path=/var/log/apiserver/audit.log
+    - --audit-log-maxage=30
+    - --audit-log-maxbackup=30
+    - --audit-log-maxsize=100
+    - --audit-policy-file=/etc/kubernetes/policies/audit-policy.yaml
+    - --encryption-provider-config=/etc/kubernetes/encryption/k8s-encryption-config.yaml
+    - --requestheader-client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
+    - --requestheader-allowed-names=aggregator,{{.Cluster.Kubernetes.API.Domain}},{{.Cluster.Kubernetes.Kubelet.Domain}}
+    - --requestheader-extra-headers-prefix=X-Remote-Extra-
+    - --requestheader-group-headers=X-Remote-Group
+    - --requestheader-username-headers=X-Remote-User
+    - --proxy-client-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
+    - --proxy-client-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    resources:
+      requests:
+        cpu: 300m
+        memory: 300Mi
+    livenessProbe:
+      tcpSocket:
+        port: {{.Cluster.Kubernetes.API.SecurePort}}
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    ports:
+    - containerPort: {{.Cluster.Kubernetes.API.SecurePort}}
+      hostPort: {{.Cluster.Kubernetes.API.SecurePort}}
+      name: https
+    volumeMounts:
+    {{ range .Hyperkube.Apiserver.Pod.HyperkubePodHostExtraMounts -}}
+    - mountPath: {{ .Path }}
+      name: {{ .Name }}
+      readOnly: {{ .ReadOnly }}
+    {{ end -}}
+    - mountPath: /var/log/apiserver/
+      name: apiserver-log
+    - mountPath: /etc/kubernetes/encryption/
+      name: k8s-encryption
+      readOnly: true
+    - mountPath: /etc/kubernetes/manifests
+      name: k8s-manifests
+      readOnly: true
+    - mountPath: /etc/kubernetes/policies
+      name: k8s-policies
+      readOnly: true
+    - mountPath: /etc/kubernetes/secrets/
+      name: k8s-secrets
+      readOnly: true
+    - mountPath: /etc/kubernetes/ssl/
+      name: ssl-certs-kubernetes
+      readOnly: true
+  volumes:
+  {{ range .Hyperkube.Apiserver.Pod.HyperkubePodHostExtraMounts -}}
+  - hostPath:
+      path: {{ .Path }}
+    name: {{ .Name }}
+  {{ end -}}
+  - hostPath:
+      path: /var/log/apiserver/
+    name: apiserver-log
+  - hostPath:
+      path: /etc/kubernetes/encryption/
+    name: k8s-encryption
+  - hostPath:
+      path: /etc/kubernetes/manifests
+    name: k8s-manifests
+  - hostPath:
+      path: /etc/kubernetes/policies
+    name: k8s-policies
+  - hostPath:
+      path: /etc/kubernetes/secrets
+    name: k8s-secrets
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes

--- a/v_4_9_1/files/manifests/k8s-controller-manager.yaml
+++ b/v_4_9_1/files/manifests/k8s-controller-manager.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: controller-manager
+    tier: control-plane
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  containers:
+  - name: k8s-controller-manager
+    image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
+    command:
+    - /hyperkube
+    - kube-controller-manager
+    {{ range .Hyperkube.ControllerManager.Pod.CommandExtraArgs -}}
+    - {{ . }}
+    {{ end -}}
+    - --logtostderr=true
+    - --v=2
+    - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
+    - --terminated-pod-gc-threshold=10
+    - --use-service-account-credentials=true
+    - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
+    - --feature-gates=TTLAfterFinished=true
+    - --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
+    - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-key.pem
+    resources:
+      requests:
+        cpu: 200m
+        memory: 200Mi
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10251
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    volumeMounts:
+    {{ range .Hyperkube.ControllerManager.Pod.HyperkubePodHostExtraMounts -}}
+    - mountPath: {{ .Path }}
+      name: {{ .Name }}
+      readOnly: {{ .ReadOnly }}
+    {{ end -}}
+    - mountPath: /etc/kubernetes/config/
+      name: k8s-config
+      readOnly: true
+    - mountPath: /etc/kubernetes/kubeconfig/
+      name: k8s-kubeconfig
+      readOnly: true
+    - mountPath: /etc/kubernetes/secrets/
+      name: k8s-secrets
+      readOnly: true
+    - mountPath: /etc/kubernetes/ssl/
+      name: ssl-certs-kubernetes
+      readOnly: true
+  volumes:
+  {{ range .Hyperkube.ControllerManager.Pod.HyperkubePodHostExtraMounts -}}
+  - hostPath:
+      path: {{ .Path }}
+    name: {{ .Name }}
+  {{ end -}}
+  - hostPath:
+      path: /etc/kubernetes/config
+    name: k8s-config
+  - hostPath:
+      path: /etc/kubernetes/kubeconfig
+    name: k8s-kubeconfig
+  - hostPath:
+      path: /etc/kubernetes/secrets
+    name: k8s-secrets
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes

--- a/v_4_9_1/files/manifests/k8s-scheduler.yaml
+++ b/v_4_9_1/files/manifests/k8s-scheduler.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s-scheduler
+  namespace: kube-system
+  labels:
+    k8s-app: scheduler
+    tier: control-plane
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  containers:
+  - name: k8s-scheduler
+    image: {{ .RegistryDomain }}/{{ .Images.Kubernetes }}
+    command:
+    - /hyperkube
+    - kube-scheduler
+    - --feature-gates=TTLAfterFinished=true
+    - --config=/etc/kubernetes/config/scheduler.yaml
+    - --v=2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10251
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    volumeMounts:
+    - mountPath: /etc/kubernetes/config/
+      name: k8s-config
+      readOnly: true
+    - mountPath: /etc/kubernetes/kubeconfig/
+      name: k8s-kubeconfig
+      readOnly: true
+    - mountPath: /etc/kubernetes/ssl/
+      name: ssl-certs-kubernetes
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/config
+    name: k8s-config
+  - hostPath:
+      path: /etc/kubernetes/kubeconfig
+    name: k8s-kubeconfig
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes

--- a/v_4_9_1/files/policies/audit-policy.yaml
+++ b/v_4_9_1/files/policies/audit-policy.yaml
@@ -1,0 +1,161 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # The following requests were manually identified as high-volume and low-risk,
+  # so drop them.
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints", "services", "services/status"]
+  - level: None
+    # Ingress controller reads 'configmaps/ingress-uid' through the unsecured port.
+    users: ["system:unsecured"]
+    namespaces: ["kube-system"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+  - level: None
+    users: ["kubelet"] # legacy kubelet identity
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    users:
+      - system:kube-controller-manager
+      - system:kube-scheduler
+      - system:serviceaccount:kube-system:endpoint-controller
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints"]
+  - level: None
+    users: ["system:apiserver"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  - level: None
+    users: ["system:serviceaccount:kube-system:cluster-autoscaler"]
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps", "endpoints"]
+  # Don't log HPA fetching metrics.
+  - level: None
+    users:
+      - system:kube-controller-manager
+    verbs: ["get", "list"]
+    resources:
+      - group: "metrics.k8s.io"
+  # Don't log these read-only URLs.
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /version
+      - /swagger*
+  # Don't log events requests.
+  - level: None
+    resources:
+      - group: "" # core
+        resources: ["events"]
+  # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+  - level: Request
+    users:
+      [
+        "kubelet",
+        "system:node-problem-detector",
+        "system:serviceaccount:kube-system:node-problem-detector",
+      ]
+    verbs: ["update", "patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  - level: Request
+    userGroups: ["system:nodes"]
+    verbs: ["update", "patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  # deletecollection calls can be large, don't log responses for expected namespace deletions
+  - level: Request
+    users: ["system:serviceaccount:kube-system:namespace-controller"]
+    verbs: ["deletecollection"]
+    omitStages:
+      - "RequestReceived"
+  # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+  # so only log at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core
+        resources: ["secrets", "configmaps"]
+      - group: authentication.k8s.io
+        resources: ["tokenreviews"]
+    omitStages:
+      - "RequestReceived"
+  # Get repsonses can be large; skip them.
+  - level: Request
+    verbs: ["get", "list", "watch"]
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for known APIs
+  - level: RequestResponse
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for all other requests.
+  - level: Metadata
+    omitStages:
+      - "RequestReceived"

--- a/v_4_9_1/master_template.go
+++ b/v_4_9_1/master_template.go
@@ -1,0 +1,632 @@
+package v_4_9_0
+
+const MasterTemplate = `---
+ignition:
+  version: "2.2.0"
+passwd:
+  users:
+    - name: giantswarm
+      shell: "/bin/bash"
+      uid: 1000
+      groups:
+        - "sudo"
+        - "docker"
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCuJvxy3FKGrfJ4XB5exEdKXiqqteXEPFzPtex6dC0lHyigtO7l+NXXbs9Lga2+Ifs0Tza92MRhg/FJ+6za3oULFo7+gDyt86DIkZkMFdnSv9+YxYe+g4zqakSV+bLVf2KP6krUGJb7t4Nb+gGH62AiUx+58Onxn5rvYC0/AXOYhkAiH8PydXTDJDPhSA/qWSWEeCQistpZEDFnaVi0e7uq/k3hWJ+v9Gz0qqChHKWWOYp3W6aiIE3G6gLOXNEBdWRrjK6xmrSmo9Toqh1G7iIV0Y6o9w5gIHJxf6+8X70DCuVDx9OLHmjjMyGnd+1c3yTFMUdugtvmeiGWE0E7ZjNSNIqWlnvYJ0E1XPBiyQ7nhitOtVvPC4kpRP7nOFiCK9n8Lr3z3p4v3GO0FU3/qvLX+ECOrYK316gtwSJMd+HIouCbaJaFGvT34peaq1uluOP/JE+rFOnszZFpCYgTY2b4lWjf2krkI/a/3NDJPnRpjoE3RjmbepkZeIdOKTCTH1xYZ3O8dWKRX8X4xORvKJO+oV2UdoZlFa/WJTmq23z4pCVm0UWDYR5C2b9fHwxh/xrPT7CQ0E+E9wmeOvR4wppDMseGQCL+rSzy2AYiQ3D8iQxk0r6T+9MyiRCfuY73p63gB3m37jMQSLHvm77MkRnYcBy61Qxk+y+ls2D0xJfqxw== giantswarm"
+{{ range $index, $user := .Cluster.Kubernetes.SSH.UserList }}
+    - name: {{ $user.Name }}
+      shell: "/bin/bash"
+      groups:
+        - "sudo"
+        - "docker"
+{{ if ne $user.PublicKey "" }}
+      sshAuthorizedKeys:
+        - "{{ $user.PublicKey }}"
+{{ end }}
+{{ end }}
+
+systemd:
+  units:
+  # Start - manual management for cgroup structure
+  - name: kubereserved.slice
+    path: /etc/systemd/system/kubereserved.slice
+    content: |
+      [Unit]
+      Description=Limited resources slice for Kubernetes services
+      Documentation=man:systemd.special(7)
+      DefaultDependencies=no
+      Before=slices.target
+      Requires=-.slice
+      After=-.slice
+  # End - manual management for cgroup structure
+  - name: audit-rules.service
+    enabled: true
+    dropins:
+    - name: 10-Wait-For-Docker.conf
+      contents: |
+        [Service]
+        ExecStartPre=/bin/bash -c "while [ ! -f /etc/audit/rules.d/10-docker.rules ]; do echo 'Waiting for /etc/audit/rules.d/10-docker.rules to be written' && sleep 1; done"
+  {{range .Extension.Units}}
+  - name: {{.Metadata.Name}}
+    enabled: {{.Metadata.Enabled}}
+    contents: |
+      {{range .Content}}{{.}}
+      {{end}}{{end}}
+  - name: set-certs-group-owner-permission-giantswarm.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Change group owner for certificates to giantswarm
+      Wants=k8s-kubelet.service k8s-setup-network-env.service
+      After=k8s-kubelet.service k8s-setup-network-env.service
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/sh -c "find /etc/kubernetes/ssl -name '*.pem' -print | xargs -i  sh -c 'chown root:giantswarm {} && chmod 640 {}'"
+      [Install]
+      WantedBy=multi-user.target
+  - name: wait-for-domains.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Wait for etcd and k8s API domains to be available
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/wait-for-domains
+      [Install]
+      WantedBy=multi-user.target
+  - name: os-hardeing.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Apply os hardening
+      [Service]
+      Type=oneshot
+      ExecStartPre=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+      ExecStartPre=/bin/bash -c "until [ -f '/etc/sysctl.d/hardening.conf' ]; do echo Waiting for sysctl file; sleep 1s;done;"
+      ExecStart=/usr/sbin/sysctl -p /etc/sysctl.d/hardening.conf
+      [Install]
+      WantedBy=multi-user.target
+  - name: k8s-setup-kubelet-config.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=k8s-setup-kubelet-config Service
+      After=k8s-setup-network-env.service docker.service
+      Requires=k8s-setup-network-env.service docker.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      TimeoutStartSec=0
+      EnvironmentFile=/etc/network-environment
+      ExecStart=/bin/bash -c '/usr/bin/envsubst </etc/kubernetes/config/kubelet.yaml.tmpl >/etc/kubernetes/config/kubelet.yaml'
+      [Install]
+      WantedBy=multi-user.target
+  - name: containerd.service
+    enabled: true
+    contents: |
+    dropins:
+      - name: 10-change-cgroup.conf
+        contents: |
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+          Slice=kubereserved.slice
+  - name: docker.service
+    enabled: true
+    contents: |
+    dropins:
+      - name: 10-giantswarm-extra-args.conf
+        contents: |
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+          Slice=kubereserved.slice
+          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/kubereserved.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+          Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
+          Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
+  - name: k8s-setup-network-env.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=k8s-setup-network-env Service
+      Wants=network.target docker.service wait-for-domains.service
+      After=network.target docker.service wait-for-domains.service
+      [Service]
+      Type=oneshot
+      TimeoutStartSec=0
+      Environment="IMAGE={{.Cluster.Kubernetes.NetworkSetup.Docker.Image}}"
+      Environment="NAME=%p.service"
+      ExecStartPre=/usr/bin/mkdir -p /opt/bin/
+      ExecStartPre=/usr/bin/docker pull $IMAGE
+      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
+      ExecStartPre=-/usr/bin/docker rm -f $NAME
+      ExecStart=/usr/bin/docker run --rm --net=host -v /etc:/etc --name $NAME $IMAGE
+      ExecStop=-/usr/bin/docker stop -t 10 $NAME
+      ExecStopPost=-/usr/bin/docker rm -f $NAME
+      [Install]
+      WantedBy=multi-user.target
+  - name: etcd3.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=etcd3
+      Wants=k8s-setup-network-env.service
+      After=k8s-setup-network-env.service
+      Conflicts=etcd.service etcd2.service
+      StartLimitIntervalSec=0
+      [Service]
+      Restart=always
+      RestartSec=0
+      TimeoutStopSec=10
+      LimitNOFILE=40000
+      CPUAccounting=true
+      MemoryAccounting=true
+      Slice=kubereserved.slice
+      Environment=IMAGE={{ .RegistryDomain }}/{{ .Images.Etcd }}
+      Environment=NAME=%p.service
+      EnvironmentFile=/etc/network-environment
+      ExecStartPre=-/usr/bin/docker stop  $NAME
+      ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
+      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
+      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-crt.pem to be written' && sleep 1; done"
+      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
+      ExecStart=/usr/bin/docker run \
+          -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
+          -v /etc/kubernetes/ssl/etcd/:/etc/etcd \
+          -v /var/lib/etcd/:/var/lib/etcd  \
+          --net=host  \
+          --name $NAME \
+          $IMAGE \
+          etcd \
+          --name etcd0 \
+          --trusted-ca-file /etc/etcd/server-ca.pem \
+          --cert-file /etc/etcd/server-crt.pem \
+          --key-file /etc/etcd/server-key.pem\
+          --client-cert-auth=true \
+          --peer-trusted-ca-file /etc/etcd/server-ca.pem \
+          --peer-cert-file /etc/etcd/server-crt.pem \
+          --peer-key-file /etc/etcd/server-key.pem \
+          --peer-client-cert-auth=true \
+          --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }} \
+          --initial-advertise-peer-urls=https://127.0.0.1:2380 \
+          --listen-client-urls=https://0.0.0.0:2379 \
+          --listen-peer-urls=https://${DEFAULT_IPV4}:2380 \
+          --initial-cluster-token k8s-etcd-cluster \
+          --initial-cluster etcd0=https://127.0.0.1:2380 \
+          --initial-cluster-state new \
+          --data-dir=/var/lib/etcd \
+          --enable-v2
+      [Install]
+      WantedBy=multi-user.target
+  - name: etcd3-defragmentation.service
+    enabled: false
+    contents: |
+      [Unit]
+      Description=etcd defragmentation job
+      After=docker.service etcd3.service
+      Requires=docker.service etcd3.service
+      [Service]
+      Type=oneshot
+      EnvironmentFile=/etc/network-environment
+      Environment=IMAGE={{ .RegistryDomain }}/{{ .Images.Etcd }}
+      Environment=NAME=%p.service
+      ExecStartPre=-/usr/bin/docker stop  $NAME
+      ExecStartPre=-/usr/bin/docker rm  $NAME
+      ExecStartPre=-/usr/bin/docker pull $IMAGE
+      ExecStart=/usr/bin/docker run \
+        -v /etc/kubernetes/ssl/etcd/:/etc/etcd \
+        --net=host  \
+        -e ETCDCTL_API=3 \
+        --name $NAME \
+        $IMAGE \
+        etcdctl \
+        --endpoints https://127.0.0.1:2379 \
+        --cacert /etc/etcd/server-ca.pem \
+        --cert /etc/etcd/server-crt.pem \
+        --key /etc/etcd/server-key.pem \
+        defrag \
+        --command-timeout=60s \
+        --dial-timeout=60s \
+        --keepalive-timeout=25s
+      [Install]
+      WantedBy=multi-user.target
+  - name: etcd3-defragmentation.timer
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Execute etcd3-defragmentation every day at 3.30AM UTC
+      [Timer]
+      OnCalendar=*-*-* 03:30:00 UTC
+      [Install]
+      WantedBy=multi-user.target
+  - name: k8s-kubelet.service
+    enabled: true
+    contents: |
+      [Unit]
+      Wants=k8s-setup-network-env.service k8s-setup-kubelet-config.service
+      After=k8s-setup-network-env.service k8s-setup-kubelet-config.service
+      Description=k8s-kubelet
+      StartLimitIntervalSec=0
+      [Service]
+      TimeoutStartSec=300
+      Restart=always
+      RestartSec=0
+      TimeoutStopSec=10
+      CPUAccounting=true
+      MemoryAccounting=true
+      Slice=kubereserved.slice
+      EnvironmentFile=/etc/network-environment
+      Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
+      Environment="NAME=%p.service"
+      Environment="PATH=/opt/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      ExecStartPre=/usr/bin/docker pull $IMAGE
+      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
+      ExecStartPre=-/usr/bin/docker rm -f $NAME
+      ExecStart=/bin/sh -c "/usr/bin/docker run --rm --pid=host --net=host --privileged=true \
+      {{ range .Hyperkube.Kubelet.Docker.RunExtraArgs -}}
+      {{ . }} \
+      {{ end -}}
+      -v /:/rootfs:ro,rshared \
+      -v /sys:/sys:ro \
+      -v /dev:/dev:rw \
+      -v /var/log:/var/log:rw \
+      -v /run/calico/:/run/calico/:rw \
+      -v /run/docker/:/run/docker/:rw \
+      -v /run/docker.sock:/run/docker.sock:rw \
+      -v /usr/bin/docker:/usr/bin/docker \
+      -v /run/metadata/torcx:/run/metadata/torcx \
+      -v /run/torcx/:/run/torcx/ \
+      -v /usr/lib/os-release:/etc/os-release \
+      -v /usr/share/ca-certificates/:/etc/ssl/certs \
+      -v /var/lib/calico/:/var/lib/calico \
+      -v /var/lib/docker/:/var/lib/docker:rw,rshared \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
+      -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
+      -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
+      -v /etc/kubernetes/kubeconfig/:/etc/kubernetes/kubeconfig/ \
+      -v /etc/kubernetes/manifests/:/etc/kubernetes/manifests/ \
+      -v /etc/cni/net.d/:/etc/cni/net.d/ \
+      -v /opt/cni/bin/:/opt/cni/bin/ \
+      -v /opt/bin:/opt/bin \
+      -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm \
+      -v /etc/iscsi/:/etc/iscsi/ \
+      -v /dev/disk/by-path/:/dev/disk/by-path/ \
+      -v /dev/mapper/:/dev/mapper/ \
+      -v /lib/modules:/lib/modules \
+      -v /usr/sbin/mkfs.xfs:/usr/sbin/mkfs.xfs \
+      -v /usr/lib64/libxfs.so.0:/usr/lib/libxfs.so.0 \
+      -v /usr/lib64/libxcmd.so.0:/usr/lib/libxcmd.so.0 \
+      -v /usr/lib64/libreadline.so.7:/usr/lib/libreadline.so.7 \
+      -e ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd/server-ca.pem \
+      -e ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd/server-crt.pem \
+      -e ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd/server-key.pem \
+      -e PATH \
+      --name $NAME \
+      $IMAGE \
+      /hyperkube kubelet \
+      {{ range .Hyperkube.Kubelet.Docker.CommandExtraArgs -}}
+      {{ . }} \
+      {{ end -}}
+      --node-ip=${DEFAULT_IPV4} \
+      --config=/etc/kubernetes/config/kubelet.yaml \
+      --containerized \
+      --enable-server \
+      --logtostderr=true \
+      --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
+      --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
+      --network-plugin=cni \
+      --register-node=true \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+      --feature-gates=TTLAfterFinished=true \
+      --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
+      --node-labels="node.kubernetes.io/master,node-role.kubernetes.io/master,kubernetes.io/role=master,role=master,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --v=2"
+      ExecStop=-/usr/bin/docker stop -t 10 $NAME
+      ExecStopPost=-/usr/bin/docker rm -f $NAME
+      [Install]
+      WantedBy=multi-user.target
+  - name: etcd2.service
+    enabled: false
+    mask: true
+  - name: update-engine.service
+    enabled: false
+    mask: true
+  - name: locksmithd.service
+    enabled: false
+    mask: true
+  - name: fleet.service
+    enabled: false
+    mask: true
+  - name: fleet.socket
+    enabled: false
+    mask: true
+  - name: flanneld.service
+    enabled: false
+    mask: true
+  - name: systemd-networkd-wait-online.service
+    enabled: false
+    mask: true
+  - name: k8s-addons.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Kubernetes Addons
+      Wants=k8s-kubelet.service k8s-setup-network-env.service
+      After=k8s-kubelet.service k8s-setup-network-env.service
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/k8s-addons
+      # https://github.com/kubernetes/kubernetes/issues/71078
+      ExecStartPost=/usr/bin/systemctl restart k8s-kubelet.service
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: debug-tools.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Install calicoctl and crictl tools
+      After=network.target
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/install-debug-tools
+      [Install]
+      WantedBy=multi-user.target
+
+storage:
+  files:
+    - path: /etc/ssh/trusted-user-ca-keys.pem
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;base64,{{ index .Files "conf/trusted-user-ca-keys.pem" }}"
+
+    {{- if not .DisableCalico }}
+    - path: /srv/calico-all.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/calico-all.yaml" }}"
+    {{- end }}
+
+    {{- if not .DisableIngressControllerService }}
+    - path: /srv/ingress-controller-svc.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/ingress-controller-svc.yaml" }}"
+    {{- end }}
+
+    - path: /etc/kubernetes/config/proxy-config.yml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "config/kube-proxy.yaml" }}"
+
+    - path: /srv/kube-proxy-config.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "config/kube-proxy.yaml" }}"
+
+    - path: /srv/kube-proxy-sa.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/kube-proxy-sa.yaml" }}"
+
+    - path: /srv/kube-proxy-ds.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/kube-proxy-ds.yaml" }}"
+
+    - path: /srv/rbac_bindings.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/rbac_bindings.yaml" }}"
+
+    - path: /srv/rbac_roles.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/rbac_roles.yaml" }}"
+
+    - path: /srv/priority_classes.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/priority_classes.yaml" }}"
+
+    - path: /srv/psp_policies.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/psp_policies.yaml" }}"
+
+    - path: /srv/psp_roles.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/psp_roles.yaml" }}"
+
+    - path: /srv/psp_binding.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/psp_bindings.yaml" }}"
+
+    - path: /opt/wait-for-domains
+      filesystem: root
+      mode: 0544
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/wait-for-domains" }}"
+
+    - path: /opt/k8s-addons
+      filesystem: root
+      mode: 0544
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/k8s-addons" }}"
+
+    - path: /etc/kubernetes/kubeconfig/addons.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/addons.yaml" }}"
+
+    - path: /etc/kubernetes/config/proxy-kubeconfig.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/kube-proxy-master.yaml" }}"
+
+    - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/kube-proxy-master.yaml" }}"
+
+    - path: /etc/kubernetes/config/kubelet.yaml.tmpl
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "config/kubelet-master.yaml.tmpl" }}"
+
+    - path: /etc/kubernetes/kubeconfig/kubelet.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/kubelet-master.yaml" }}"
+
+    - path: /etc/kubernetes/kubeconfig/controller-manager.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/controller-manager.yaml" }}"
+
+    - path: /etc/kubernetes/config/scheduler.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "config/scheduler.yaml" }}"
+
+    - path: /etc/kubernetes/kubeconfig/scheduler.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/scheduler.yaml" }}"
+
+    {{ if not .DisableEncryptionAtREST -}}
+    - path: /etc/kubernetes/encryption/k8s-encryption-config.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/k8s-encryption-config.yaml" }}"
+
+    {{ end -}}
+    - path: /etc/kubernetes/policies/audit-policy.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "policies/audit-policy.yaml" }}"
+    - path: /etc/kubernetes/manifests/k8s-api-healthz.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "manifests/k8s-api-healthz.yaml" }}"
+
+    - path: /etc/kubernetes/manifests/k8s-api-server.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "manifests/k8s-api-server.yaml" }}"
+
+    - path: /etc/kubernetes/manifests/k8s-controller-manager.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "manifests/k8s-controller-manager.yaml" }}"
+
+    - path: /etc/kubernetes/manifests/k8s-scheduler.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "manifests/k8s-scheduler.yaml" }}"
+
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/sshd_config" }}"
+
+    - path: /etc/sysctl.d/hardening.conf
+      filesystem: root
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/hardening.conf" }}"
+
+    - path: /etc/audit/rules.d/10-docker.rules
+      filesystem: root
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/10-docker.rules" }}"
+
+    - path: /etc/modules-load.d/ip_vs.conf
+      filesystem: root
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/ip_vs.conf" }}"
+
+    - path: /opt/install-debug-tools
+      filesystem: root
+      mode: 0544
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/install-debug-tools" }}"
+
+    - path: /etc/calico/calicoctl.cfg
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/calicoctl.cfg" }}"
+
+    - path: /etc/crictl.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl" }}"
+
+    - path: /etc/profile.d/setup-etcdctl.sh
+      filesystem: root
+      mode: 0444
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/etcd-alias" }}"
+
+    {{ range .Extension.Files -}}
+    - path: {{ .Metadata.Path }}
+      filesystem: root
+      user:
+      {{- if .Metadata.Owner.User.ID }}
+        id: {{ .Metadata.Owner.User.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.User.Name }}
+      {{- end }}
+      group:
+      {{- if .Metadata.Owner.Group.ID }}
+        id: {{ .Metadata.Owner.Group.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.Group.Name }}
+      {{- end }}
+      mode: {{printf "%#o" .Metadata.Permissions}}
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{ .Content }}"
+        {{ if .Metadata.Compression }}
+        compression: gzip
+        {{end}}
+    {{ end -}}
+
+{{ range .Extension.VerbatimSections }}
+{{ .Content }}
+{{ end }}
+`

--- a/v_4_9_1/master_template_test.go
+++ b/v_4_9_1/master_template_test.go
@@ -1,0 +1,50 @@
+package v_4_9_0
+
+import (
+	"testing"
+	"text/template"
+)
+
+func Test_MasterTemplate(t *testing.T) {
+	tmpl, err := template.New("").Parse(MasterTemplate)
+	if err != nil {
+		t.Fatalf("expected err = nil, got %v", err)
+	}
+
+	// Test with empty struct parameters. This should fail with field
+	// evaluation.
+	{
+		params := struct{}{}
+
+		err := tmpl.Execute(nopWriter{}, params)
+		if err == nil {
+			t.Fatalf("expected err != nil, got nil")
+		}
+	}
+
+	// Test with Params struct. This should contain all evaluated fields.
+	{
+		params := Params{
+			// Extension has to be set because it's interface and
+			// template evaluation will panic otherwise.
+			Extension: nopExtension{},
+		}
+
+		packagePath, err := GetPackagePath()
+		if err != nil {
+			t.Error(err)
+		}
+		ignitionPath := GetIgnitionPath(packagePath)
+
+		files, err := RenderFiles(ignitionPath, params)
+		if err != nil {
+			t.Errorf("failed to render ignition files, %v:", err)
+		}
+		params.Files = files
+
+		err = tmpl.Execute(new(nopWriter), params)
+		if err != nil {
+			t.Fatalf("failed to execute master template, expected err = nil, got %v", err)
+		}
+	}
+}

--- a/v_4_9_1/render_asset_content.go
+++ b/v_4_9_1/render_asset_content.go
@@ -1,0 +1,43 @@
+package v_4_9_0
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"text/template"
+
+	"github.com/giantswarm/microerror"
+)
+
+func RenderAssetContent(assetContent string, params interface{}) ([]string, error) {
+	tmpl, err := template.New("").Parse(assetContent)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	if err := tmpl.Execute(buf, params); err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	content := strings.Split(buf.String(), "\n")
+	return content, nil
+}
+
+// RenderFileAssetContent returns base64 representation of the rendered assetContent.
+func RenderFileAssetContent(assetContent string, params interface{}) (string, error) {
+	tmpl, err := template.New("").Parse(assetContent)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	if err := tmpl.Execute(buf, params); err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	content := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return content, nil
+}

--- a/v_4_9_1/render_asset_content_test.go
+++ b/v_4_9_1/render_asset_content_test.go
@@ -1,0 +1,63 @@
+package v_4_9_0
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testTemplate = `foo: {{.Foo}}`
+)
+
+type FakeParams struct {
+	Foo string
+}
+
+func TestRenderAssetContent(t *testing.T) {
+	tests := []struct {
+		assetContent    string
+		params          FakeParams
+		expectedContent []string
+	}{
+		{
+			assetContent:    testTemplate,
+			params:          FakeParams{Foo: "bar"},
+			expectedContent: []string{"foo: bar"},
+		},
+	}
+
+	for _, tc := range tests {
+		content, err := RenderAssetContent(tc.assetContent, tc.params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Join(content, "\n") != strings.Join(tc.expectedContent, "\n") {
+			t.Fatalf("expected %#v, got %#v", tc.expectedContent, content)
+		}
+	}
+}
+
+func TestRenderFileAssetContent(t *testing.T) {
+	tests := []struct {
+		assetContent    string
+		params          FakeParams
+		expectedContent string
+	}{
+		{
+			assetContent: testTemplate,
+			params:       FakeParams{Foo: "bar"},
+			// expected base64 encoding of `foo: bar`
+			expectedContent: "Zm9vOiBiYXI=",
+		},
+	}
+
+	for _, tc := range tests {
+		content, err := RenderFileAssetContent(tc.assetContent, tc.params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if content != tc.expectedContent {
+			t.Fatalf("expected %#v, got %#v", tc.expectedContent, content)
+		}
+	}
+}

--- a/v_4_9_1/types.go
+++ b/v_4_9_1/types.go
@@ -1,0 +1,148 @@
+package v_4_9_0
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+)
+
+type Params struct {
+	// APIServerEncryptionKey is AES-CBC with PKCS#7 padding key to encrypt API
+	// etcd data.
+	APIServerEncryptionKey string
+	BaseDomain             string
+	Cluster                v1alpha1.Cluster
+	// DisableCalico flag. When set removes all calico related Kubernetes
+	// manifests from the cloud config together with their initialization.
+	DisableCalico bool
+	// DisableEncryptionAtREST flag. When set removes all manifests from the cloud
+	// config related to Kubernetes encryption at REST.
+	DisableEncryptionAtREST bool
+	// DisableIngressControllerService flag. When set removes the manifest for
+	// the Ingress Controller service. This allows us to migrate providers to
+	// chart-operator independently.
+	DisableIngressControllerService bool
+	// Hyperkube allows to pass extra `docker run` and `command` arguments
+	// to hyperkube image commands. This allows to e.g. add cloud provider
+	// extensions.
+	Hyperkube Hyperkube
+	// EtcdPort allows the Etcd port to be specified.
+	// aws-operator sets this to the Etcd listening port so Calico on the
+	// worker nodes can access via a CNAME record to the master.
+	EtcdPort  int
+	Extension Extension
+	// ExtraManifests allows to specify extra Kubernetes manifests in
+	// /opt/k8s-addons script. The manifests are applied after calico is
+	// ready.
+	//
+	// The general use-case is to create a manifest file with Extension and
+	// then apply the manifest by adding it to ExtraManifests.
+	ExtraManifests []string
+	Files          Files
+	// ImagePullProgressDeadline is the duration after which image pulling is
+	// cancelled if no progress has been made.
+	ImagePullProgressDeadline string
+	Node                      v1alpha1.ClusterNode
+	// RegistryDomain is the host of the docker image registry to use.
+	RegistryDomain string
+	SSOPublicKey   string
+	// Container images used in the cloud-config templates
+	Images Images
+}
+
+func (p *Params) Validate() error {
+	return nil
+}
+
+type Images struct {
+	Kubernetes string
+	Etcd       string
+}
+
+type Hyperkube struct {
+	Apiserver         HyperkubeApiserver
+	ControllerManager HyperkubeControllerManager
+	Kubelet           HyperkubeKubelet
+}
+
+type HyperkubeApiserver struct {
+	Pod HyperkubePod
+}
+
+type HyperkubeControllerManager struct {
+	Pod HyperkubePod
+}
+
+type HyperkubeKubelet struct {
+	Docker HyperkubeDocker
+}
+
+type HyperkubeDocker struct {
+	RunExtraArgs     []string
+	CommandExtraArgs []string
+}
+
+type HyperkubePod struct {
+	HyperkubePodHostExtraMounts []HyperkubePodHostMount
+	CommandExtraArgs            []string
+}
+
+type HyperkubePodHostMount struct {
+	Name     string
+	Path     string
+	ReadOnly bool
+}
+
+type FileMetadata struct {
+	AssetContent string
+	Path         string
+	Owner        Owner
+	Compression  bool
+	Permissions  int
+}
+
+type Owner struct {
+	Group Group
+	User  User
+}
+
+// Group object reflects spec for ignition Group object.
+// If both ID and name are specified, ID is preferred.
+type Group struct {
+	ID   int
+	Name string
+}
+
+// User object reflects spec for ignition User object.
+// If both ID and name are specified, ID is preferred.
+type User struct {
+	ID   int
+	Name string
+}
+
+type FileAsset struct {
+	Metadata FileMetadata
+	Content  string
+}
+
+type UnitMetadata struct {
+	AssetContent string
+	Name         string
+	Enabled      bool
+}
+
+type UnitAsset struct {
+	Metadata UnitMetadata
+	Content  []string
+}
+
+// VerbatimSection is a blob of YAML we want to add to the
+// CloudConfig, with no variable interpolation.
+type VerbatimSection struct {
+	Name    string
+	Content string
+}
+
+type Extension interface {
+	Files() ([]FileAsset, error)
+	Units() ([]UnitAsset, error)
+	VerbatimSections() []VerbatimSection
+}

--- a/v_4_9_1/worker_template.go
+++ b/v_4_9_1/worker_template.go
@@ -1,0 +1,342 @@
+package v_4_9_0
+
+const WorkerTemplate = `---
+ignition:
+  version: "2.2.0"
+passwd:
+  users:
+    - name: giantswarm
+      shell: "/bin/bash"
+      uid: 1000
+      groups:
+        - "sudo"
+        - "docker"
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCuJvxy3FKGrfJ4XB5exEdKXiqqteXEPFzPtex6dC0lHyigtO7l+NXXbs9Lga2+Ifs0Tza92MRhg/FJ+6za3oULFo7+gDyt86DIkZkMFdnSv9+YxYe+g4zqakSV+bLVf2KP6krUGJb7t4Nb+gGH62AiUx+58Onxn5rvYC0/AXOYhkAiH8PydXTDJDPhSA/qWSWEeCQistpZEDFnaVi0e7uq/k3hWJ+v9Gz0qqChHKWWOYp3W6aiIE3G6gLOXNEBdWRrjK6xmrSmo9Toqh1G7iIV0Y6o9w5gIHJxf6+8X70DCuVDx9OLHmjjMyGnd+1c3yTFMUdugtvmeiGWE0E7ZjNSNIqWlnvYJ0E1XPBiyQ7nhitOtVvPC4kpRP7nOFiCK9n8Lr3z3p4v3GO0FU3/qvLX+ECOrYK316gtwSJMd+HIouCbaJaFGvT34peaq1uluOP/JE+rFOnszZFpCYgTY2b4lWjf2krkI/a/3NDJPnRpjoE3RjmbepkZeIdOKTCTH1xYZ3O8dWKRX8X4xORvKJO+oV2UdoZlFa/WJTmq23z4pCVm0UWDYR5C2b9fHwxh/xrPT7CQ0E+E9wmeOvR4wppDMseGQCL+rSzy2AYiQ3D8iQxk0r6T+9MyiRCfuY73p63gB3m37jMQSLHvm77MkRnYcBy61Qxk+y+ls2D0xJfqxw== giantswarm"
+{{ range $index, $user := .Cluster.Kubernetes.SSH.UserList }}
+    - name: {{ $user.Name }}
+      shell: "/bin/bash"
+      groups:
+        - "sudo"
+        - "docker"
+{{ if ne $user.PublicKey "" }}
+      sshAuthorizedKeys:
+        - "{{ $user.PublicKey }}"
+{{ end }}
+{{ end }}
+
+systemd:
+  units:
+  # Start - manual management for cgroup structure
+  - name: kubereserved.slice
+    path: /etc/systemd/system/kubereserved.slice
+    content: |
+      [Unit]
+      Description=Limited resources slice for Kubernetes services
+      Documentation=man:systemd.special(7)
+      DefaultDependencies=no
+      Before=slices.target
+      Requires=-.slice
+      After=-.slice
+  # End - manual management for cgroup structure
+  {{range .Extension.Units}}
+  - name: {{.Metadata.Name}}
+    enabled: {{.Metadata.Enabled}}
+    contents: |
+      {{range .Content}}{{.}}
+      {{end}}{{end}}
+  - name: set-certs-group-owner-permission-giantswarm.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Change group owner for certificates to giantswarm
+      Wants=k8s-kubelet.service k8s-setup-network-env.service
+      After=k8s-kubelet.service k8s-setup-network-env.service
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/sh -c "find /etc/kubernetes/ssl -name '*.pem' -print | xargs -i  sh -c 'chown root:giantswarm {} && chmod 640 {}'"
+      [Install]
+      WantedBy=multi-user.target
+  - name: wait-for-domains.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Wait for etcd and k8s API domains to be available
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/wait-for-domains
+      [Install]
+      WantedBy=multi-user.target
+  - name: os-hardeing.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Apply os hardening
+      [Service]
+      Type=oneshot
+      ExecStartPre=-/bin/bash -c "gpasswd -d core rkt; gpasswd -d core docker; gpasswd -d core wheel"
+      ExecStartPre=/bin/bash -c "until [ -f '/etc/sysctl.d/hardening.conf' ]; do echo Waiting for sysctl file; sleep 1s;done;"
+      ExecStart=/usr/sbin/sysctl -p /etc/sysctl.d/hardening.conf
+      [Install]
+      WantedBy=multi-user.target
+  - name: k8s-setup-kubelet-config.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=k8s-setup-kubelet-config Service
+      After=k8s-setup-network-env.service docker.service
+      Requires=k8s-setup-network-env.service docker.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      TimeoutStartSec=0
+      EnvironmentFile=/etc/network-environment
+      ExecStart=/bin/bash -c '/usr/bin/envsubst </etc/kubernetes/config/kubelet.yaml.tmpl >/etc/kubernetes/config/kubelet.yaml'
+      [Install]
+      WantedBy=multi-user.target
+  - name: containerd.service
+    enabled: true
+    contents: |
+    dropins:
+      - name: 10-change-cgroup.conf
+        contents: |
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+          Slice=kubereserved.slice
+  - name: docker.service
+    enabled: true
+    contents: |
+    dropins:
+      - name: 10-giantswarm-extra-args.conf
+        contents: |
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+          Slice=kubereserved.slice
+          Environment="DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs --cgroup-parent=/kubereserved.slice --log-opt max-size=25m --log-opt max-file=2 --log-opt labels=io.kubernetes.container.hash,io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid"
+          Environment="DOCKER_OPT_BIP=--bip={{.Cluster.Docker.Daemon.CIDR}}"
+          Environment="DOCKER_OPTS=--live-restore --icc=false --userland-proxy=false"
+  - name: k8s-setup-network-env.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=k8s-setup-network-env Service
+      Wants=network.target docker.service wait-for-domains.service
+      After=network.target docker.service wait-for-domains.service
+      [Service]
+      Type=oneshot
+      TimeoutStartSec=0
+      Environment="IMAGE={{.Cluster.Kubernetes.NetworkSetup.Docker.Image}}"
+      Environment="NAME=%p.service"
+      ExecStartPre=/usr/bin/mkdir -p /opt/bin/
+      ExecStartPre=/usr/bin/docker pull $IMAGE
+      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
+      ExecStartPre=-/usr/bin/docker rm -f $NAME
+      ExecStart=/usr/bin/docker run --rm --net=host -v /etc:/etc --name $NAME $IMAGE
+      ExecStop=-/usr/bin/docker stop -t 10 $NAME
+      ExecStopPost=-/usr/bin/docker rm -f $NAME
+      [Install]
+      WantedBy=multi-user.target
+  - name: k8s-kubelet.service
+    enabled: true
+    contents: |
+      [Unit]
+      Wants=k8s-setup-network-env.service k8s-setup-kubelet-config.service
+      After=k8s-setup-network-env.service k8s-setup-kubelet-config.service
+      Description=k8s-kubelet
+      StartLimitIntervalSec=0
+
+      [Service]
+      TimeoutStartSec=300
+      Restart=always
+      RestartSec=0
+      TimeoutStopSec=10
+      CPUAccounting=true
+      MemoryAccounting=true
+      Slice=kubereserved.slice
+      EnvironmentFile=/etc/network-environment
+      Environment="IMAGE={{ .RegistryDomain }}/{{ .Images.Kubernetes }}"
+      Environment="NAME=%p.service"
+      Environment="PATH=/opt/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      ExecStartPre=/usr/bin/docker pull $IMAGE
+      ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
+      ExecStartPre=-/usr/bin/docker rm -f $NAME
+      ExecStart=/bin/sh -c "/usr/bin/docker run --rm --pid=host --net=host --privileged=true \
+      {{ range .Hyperkube.Kubelet.Docker.RunExtraArgs -}}
+      {{ . }} \
+      {{ end -}}
+      -v /:/rootfs:ro,rshared \
+      -v /sys:/sys:ro \
+      -v /dev:/dev:rw \
+      -v /var/log:/var/log:rw \
+      -v /run/calico/:/run/calico/:rw \
+      -v /run/docker/:/run/docker/:rw \
+      -v /run/docker.sock:/run/docker.sock:rw \
+      -v /usr/bin/docker:/usr/bin/docker \
+      -v /run/metadata/torcx:/run/metadata/torcx \
+      -v /run/torcx/:/run/torcx/ \
+      -v /usr/lib/os-release:/etc/os-release \
+      -v /usr/share/ca-certificates/:/etc/ssl/certs \
+      -v /var/lib/calico/:/var/lib/calico \
+      -v /var/lib/docker/:/var/lib/docker:rw,rshared \
+      -v /var/lib/kubelet/:/var/lib/kubelet:rw,rshared \
+      -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
+      -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
+      -v /etc/kubernetes/kubeconfig/:/etc/kubernetes/kubeconfig/ \
+      -v /etc/cni/net.d/:/etc/cni/net.d/ \
+      -v /opt/cni/bin/:/opt/cni/bin/ \
+      -v /opt/bin:/opt/bin \
+      -v /usr/sbin/iscsiadm:/usr/sbin/iscsiadm \
+      -v /etc/iscsi/:/etc/iscsi/ \
+      -v /dev/disk/by-path/:/dev/disk/by-path/ \
+      -v /dev/mapper/:/dev/mapper/ \
+      -v /lib/modules:/lib/modules \
+      -v /usr/sbin/mkfs.xfs:/usr/sbin/mkfs.xfs \
+      -v /usr/lib64/libxfs.so.0:/usr/lib/libxfs.so.0 \
+      -v /usr/lib64/libxcmd.so.0:/usr/lib/libxcmd.so.0 \
+      -v /usr/lib64/libreadline.so.7:/usr/lib/libreadline.so.7 \
+      -e ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd/client-ca.pem \
+      -e ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd/client-crt.pem \
+      -e ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd/client-key.pem \
+      -e PATH \
+      --name $NAME \
+      $IMAGE \
+      /hyperkube kubelet \
+      {{ range .Hyperkube.Kubelet.Docker.CommandExtraArgs -}}
+      {{ . }} \
+      {{ end -}}
+      --node-ip=${DEFAULT_IPV4} \
+      --config=/etc/kubernetes/config/kubelet.yaml \
+      --containerized \
+      --enable-server \
+      --logtostderr=true \
+      --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
+      --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
+      --network-plugin=cni \
+      --register-node=true \
+      --feature-gates=TTLAfterFinished=true \
+      --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
+      --node-labels="node.kubernetes.io/worker,node-role.kubernetes.io/worker,kubernetes.io/role=worker,role=worker,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \
+      --v=2"
+      ExecStop=-/usr/bin/docker stop -t 10 $NAME
+      ExecStopPost=-/usr/bin/docker rm -f $NAME
+      [Install]
+      WantedBy=multi-user.target
+  - name: etcd2.service
+    enabled: false
+    mask: true
+  - name: update-engine.service
+    enabled: false
+    mask: true
+  - name: locksmithd.service
+    enabled: false
+    mask: true
+  - name: fleet.service
+    enabled: false
+    mask: true
+  - name: fleet.socket
+    enabled: false
+    mask: true
+  - name: flanneld.service
+    enabled: false
+    mask: true
+  - name: systemd-networkd-wait-online.service
+    enabled: false
+    mask: true
+
+storage:
+  files:
+    - path: /etc/ssh/trusted-user-ca-keys.pem
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;base64,{{ index .Files "conf/trusted-user-ca-keys.pem" }}"
+
+    - path: /etc/kubernetes/config/kubelet.yaml.tmpl
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "config/kubelet-worker.yaml.tmpl" }}"
+
+    - path: /etc/kubernetes/kubeconfig/kubelet.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/kubelet-worker.yaml" }}"
+
+    - path: /etc/kubernetes/config/proxy-config.yml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "config/kube-proxy.yaml" }}"
+
+    - path: /etc/kubernetes/config/proxy-kubeconfig.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/kube-proxy-worker.yaml" }}"
+
+    - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "kubeconfig/kube-proxy-worker.yaml" }}"
+
+    - path: /opt/wait-for-domains
+      filesystem: root
+      mode: 0544
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/wait-for-domains" }}"
+
+    - path: /etc/ssh/sshd_config
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/sshd_config" }}"
+
+    - path: /etc/sysctl.d/hardening.conf
+      filesystem: root
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/hardening.conf" }}"
+
+    - path: /etc/audit/rules.d/10-docker.rules
+      filesystem: root
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/10-docker.rules" }}"
+
+    - path: /etc/modules-load.d/ip_vs.conf
+      filesystem: root
+      mode: 0600
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/ip_vs.conf" }}"
+
+    {{ range .Extension.Files -}}
+    - path: {{ .Metadata.Path }}
+      filesystem: root
+      user:
+      {{- if .Metadata.Owner.User.ID }}
+        id: {{ .Metadata.Owner.User.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.User.Name }}
+      {{- end }}
+      group:
+      {{- if .Metadata.Owner.Group.ID }}
+        id: {{ .Metadata.Owner.Group.ID }}
+      {{- else }}
+        name: {{ .Metadata.Owner.Group.Name }}
+      {{- end }}
+      mode: {{printf "%#o" .Metadata.Permissions}}
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{ .Content }}"
+        {{ if .Metadata.Compression }}
+        compression: gzip
+        {{end}}
+    {{ end -}}
+
+{{ range .Extension.VerbatimSections }}
+{{ .Content }}
+{{ end }}
+`

--- a/v_4_9_1/worker_template_test.go
+++ b/v_4_9_1/worker_template_test.go
@@ -1,0 +1,50 @@
+package v_4_9_0
+
+import (
+	"testing"
+	"text/template"
+)
+
+func Test_WorkerTemplate(t *testing.T) {
+	tmpl, err := template.New("").Parse(WorkerTemplate)
+	if err != nil {
+		t.Fatalf("expected err = nil, got %v", err)
+	}
+
+	// Test with empty struct parameters. This should fail with field
+	// evaluation.
+	{
+		params := struct{}{}
+
+		err := tmpl.Execute(nopWriter{}, params)
+		if err == nil {
+			t.Fatalf("expected err != nil, got nil")
+		}
+	}
+
+	// Test with Params struct. This should contain all evaluated fields.
+	{
+		params := Params{
+			// Extension has to be set because it's interface and
+			// template evaluation will panic otherwise.
+			Extension: nopExtension{},
+		}
+
+		packagePath, err := GetPackagePath()
+		if err != nil {
+			t.Error(err)
+		}
+		ignitionPath := GetIgnitionPath(packagePath)
+
+		files, err := RenderFiles(ignitionPath, params)
+		if err != nil {
+			t.Errorf("failed to render ignition files, %v:", err)
+		}
+		params.Files = files
+
+		err = tmpl.Execute(new(nopWriter), params)
+		if err != nil {
+			t.Fatalf("failed to execute master template, expected err = nil, got %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8436

`aws-operator@5.5.0` uses [k8scloudconfig v_4_9_0](https://github.com/giantswarm/aws-operator/blob/d0af87284deb59eca4035772db2c68866bfe251a/Gopkg.lock#L418). To implement "versions from releases", we therefore need to create a new patch `k8scloudconfig` version based on `v_4_9_0` which allows all image fields to be templated.