### PR TITLE
fix go module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix go module.
+
 
 
 ## [v6.0.0]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/k8scloudconfig
+module github.com/giantswarm/k8scloudconfig/v6
 
 go 1.13
 

--- a/v_4_0_0/cloudconfig.go
+++ b/v_4_0_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_0_0/cloudconfig_test.go
+++ b/v_4_0_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_0_1/cloudconfig.go
+++ b/v_4_0_1/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_0_1/cloudconfig_test.go
+++ b/v_4_0_1/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_10_0/cloudconfig.go
+++ b/v_4_10_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_10_0/cloudconfig_test.go
+++ b/v_4_10_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_1_0/cloudconfig.go
+++ b/v_4_1_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_1_0/cloudconfig_test.go
+++ b/v_4_1_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_1_1/cloudconfig.go
+++ b/v_4_1_1/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_1_1/cloudconfig_test.go
+++ b/v_4_1_1/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_1_2/cloudconfig.go
+++ b/v_4_1_2/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_1_2/cloudconfig_test.go
+++ b/v_4_1_2/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_2_0/cloudconfig.go
+++ b/v_4_2_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_2_0/cloudconfig_test.go
+++ b/v_4_2_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_3_0/cloudconfig.go
+++ b/v_4_3_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_3_0/cloudconfig_test.go
+++ b/v_4_3_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_4_0/cloudconfig.go
+++ b/v_4_4_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_4_0/cloudconfig_test.go
+++ b/v_4_4_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_5_0/cloudconfig.go
+++ b/v_4_5_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_5_0/cloudconfig_test.go
+++ b/v_4_5_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_5_1/cloudconfig.go
+++ b/v_4_5_1/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_5_1/cloudconfig_test.go
+++ b/v_4_5_1/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_6_0/cloudconfig.go
+++ b/v_4_6_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_6_0/cloudconfig_test.go
+++ b/v_4_6_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_7_0/cloudconfig.go
+++ b/v_4_7_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_7_0/cloudconfig_test.go
+++ b/v_4_7_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_8_0/cloudconfig.go
+++ b/v_4_8_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_8_0/cloudconfig_test.go
+++ b/v_4_8_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_8_1/cloudconfig.go
+++ b/v_4_8_1/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_8_1/cloudconfig_test.go
+++ b/v_4_8_1/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_9_0/cloudconfig.go
+++ b/v_4_9_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_9_0/cloudconfig_test.go
+++ b/v_4_9_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_4_9_1/cloudconfig.go
+++ b/v_4_9_1/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_4_9_1/cloudconfig_test.go
+++ b/v_4_9_1/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_5_0_0/cloudconfig.go
+++ b/v_5_0_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_5_0_0/cloudconfig_test.go
+++ b/v_5_0_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_5_1_0/cloudconfig.go
+++ b/v_5_1_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_5_1_0/cloudconfig_test.go
+++ b/v_5_1_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_5_2_0/cloudconfig.go
+++ b/v_5_2_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_5_2_0/cloudconfig_test.go
+++ b/v_5_2_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/v_6_0_0/cloudconfig.go
+++ b/v_6_0_0/cloudconfig.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 const (

--- a/v_6_0_0/cloudconfig_test.go
+++ b/v_6_0_0/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	ignition "github.com/giantswarm/k8scloudconfig/ignition/v_2_2_0"
+	ignition "github.com/giantswarm/k8scloudconfig/v6/ignition/v_2_2_0"
 )
 
 func TestCloudConfig(t *testing.T) {


### PR DESCRIPTION
In https://github.com/giantswarm/aws-operator/pull/2229 I noticed the `k8scloudconfig` import with go modules does not work. So Pawel and I figured we need to suffix the module name itself with the tagged version, which is `v6.0.0` here. In `aws-operator` for instance we then need to fix the imports of `k8scloudconfig` and only then we can use the real tag in the import for go modules.


## Checklist

- [x] Update changelog in CHANGELOG.md.
