### PR TITLE
legacy: Remove init limits for calico (#677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ version directory, and  then changes are introduced.
 
 ## [v4.9.1] - 2020-03-10
 
+### Added
+
+- Add `conntrackMaxPerCore` parameter in `kube-proxy` manifest.
+
+### Removed
+
+- Remove resource limits from calico-node init container.
+
 ## [v4.9.0] - 2019-10-17
 
 ### Changed

--- a/v_4_9_1/files/k8s-resource/calico-all.yaml
+++ b/v_4_9_1/files/k8s-resource/calico-all.yaml
@@ -344,9 +344,6 @@ spec:
             requests:
               cpu: 50m
               memory: 100Mi
-            limits:
-              cpu: 50m
-              memory: 100Mi
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
Cherry pick of #677 for dep-based operators. Will be released as 0.1.1.

## Checklist

- [x] Update changelog in CHANGELOG.md.
