### PR TITLE
legacy: Add missing wiring for k8s-network-setup container image (#668)

### DIFF
--- a/v_6_0_0/release.go
+++ b/v_6_0_0/release.go
@@ -9,13 +9,14 @@ import (
 
 func BuildImages(registryDomain string, versions Versions) Images {
 	return Images{
-		CalicoCNI:             buildImage(registryDomain, "giantswarm/cni", versions.Calico),
-		CalicoKubeControllers: buildImage(registryDomain, "giantswarm/kube-controllers", versions.Calico),
-		CalicoNode:            buildImage(registryDomain, "giantswarm/node", versions.Calico),
-		Etcd:                  buildImage(registryDomain, "giantswarm/etcd", versions.Etcd),
-		Hyperkube:             buildImage(registryDomain, "giantswarm/hyperkube", versions.Kubernetes),
-		Kubectl:               buildImage(registryDomain, "giantswarm/docker-kubectl", versions.Kubectl),
-		KubernetesAPIHealthz:  buildImage(registryDomain, "giantswarm/k8s-api-healthz", versions.KubernetesAPIHealthz),
+		CalicoCNI:                    buildImage(registryDomain, "giantswarm/cni", versions.Calico),
+		CalicoKubeControllers:        buildImage(registryDomain, "giantswarm/kube-controllers", versions.Calico),
+		CalicoNode:                   buildImage(registryDomain, "giantswarm/node", versions.Calico),
+		Etcd:                         buildImage(registryDomain, "giantswarm/etcd", versions.Etcd),
+		Hyperkube:                    buildImage(registryDomain, "giantswarm/hyperkube", versions.Kubernetes),
+		Kubectl:                      buildImage(registryDomain, "giantswarm/docker-kubectl", versions.Kubectl),
+		KubernetesAPIHealthz:         buildImage(registryDomain, "giantswarm/k8s-api-healthz", versions.KubernetesAPIHealthz),
+		KubernetesNetworkSetupDocker: buildImage(registryDomain, "giantswarm/k8s-setup-network-environment", versions.KubernetesNetworkSetupDocker),
 	}
 }
 

--- a/v_6_0_0/types.go
+++ b/v_6_0_0/types.go
@@ -53,12 +53,13 @@ func (p *Params) Validate() error {
 }
 
 type Versions struct {
-	Calico               string
-	CRITools             string
-	Etcd                 string
-	Kubectl              string
-	Kubernetes           string
-	KubernetesAPIHealthz string
+	Calico                       string
+	CRITools                     string
+	Etcd                         string
+	Kubectl                      string
+	Kubernetes                   string
+	KubernetesAPIHealthz         string
+	KubernetesNetworkSetupDocker string
 }
 
 type Debug struct {


### PR DESCRIPTION
Legacy port of #668.

Wiring to pass container image version for k8s-network-setup was missing but
it's required. Therefore add it.

## Checklist

- [x] Update changelog in CHANGELOG.md.
