### PR TITLE
Document branches in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ Examples:
 - "Hyperkube upgrade from 1.9.5 to 1.10.1" is a minor version upgrade.
 - "New field `DisableCalico` added to `Params` struct" is a major version upgrade.
 - "Kubelet configuration changed to prevent stuck in terminating state pods" is a patch version upgrade.
+
+## Branches
+
+- `legacy`
+    - All versions matching ~0.1.0.
+    - For dep-based operators.
+- `master`
+    - From version v6.0.0.
+    - For operators using go modules.


### PR DESCRIPTION
Following from https://github.com/giantswarm/k8scloudconfig/pull/682

Since we will have a long-lived branch `legacy` until active provider operators are all updated to use go modules, these branches should be documented to help decide where to target future changes.