### PR TITLE
filemanager: handler initial filepath.Walk error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,15 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+### Fixed
 
+- better error handling for filemanager
 
 ## [v6.0.1]
 
 ### Fixed
 
 - Fix go module.
-
-
 
 ## [v6.0.0]
 
@@ -548,13 +548,8 @@ chart-operator).
 
 
 [Unreleased]: https://github.com/giantswarm/k8scloudconfig/compare/v6.0.1...HEAD
-
 [v6.0.1]: https://github.com/giantswarm/k8scloudconfig/compare/v6.0.0...v6.0.1
-
 [v6.0.0]: https://github.com/giantswarm/k8scloudconfig/releases/tag/v6.0.0
-
-
-
 [v5.2.0]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_5_2_0
 [v5.1.1]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_5_1_1
 [v5.1.0]: https://github.com/giantswarm/k8scloudconfig/commits/master/v_5_1_0

--- a/v_4_0_0/filemanager.go
+++ b/v_4_0_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_0_1/filemanager.go
+++ b/v_4_0_1/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_10_0/filemanager.go
+++ b/v_4_10_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_1_0/filemanager.go
+++ b/v_4_1_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_1_1/filemanager.go
+++ b/v_4_1_1/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_1_2/filemanager.go
+++ b/v_4_1_2/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_2_0/filemanager.go
+++ b/v_4_2_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_3_0/filemanager.go
+++ b/v_4_3_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_4_0/filemanager.go
+++ b/v_4_4_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_5_0/filemanager.go
+++ b/v_4_5_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_5_1/filemanager.go
+++ b/v_4_5_1/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_6_0/filemanager.go
+++ b/v_4_6_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_7_0/filemanager.go
+++ b/v_4_7_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_8_0/filemanager.go
+++ b/v_4_8_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_8_1/filemanager.go
+++ b/v_4_8_1/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_9_0/filemanager.go
+++ b/v_4_9_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_4_9_1/filemanager.go
+++ b/v_4_9_1/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_5_0_0/filemanager.go
+++ b/v_5_0_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_5_1_0/filemanager.go
+++ b/v_5_1_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_5_2_0/filemanager.go
+++ b/v_5_2_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {

--- a/v_6_0_0/filemanager.go
+++ b/v_6_0_0/filemanager.go
@@ -30,6 +30,9 @@ func RenderFiles(filesdir string, ctx interface{}) (Files, error) {
 	files := Files{}
 
 	err := filepath.Walk(filesdir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		if f.Mode().IsRegular() {
 			tmpl, err := template.ParseFiles(path)
 			if err != nil {


### PR DESCRIPTION
This helps us avoid panic and returns a nice error when something is
**really** wrong with the file structure e.g. it is not there.

FYI: This popped up while debugging go-module-based aws-operator.

## Checklist

- [x] Update changelog in CHANGELOG.md.
