### PR TITLE
Remove unused kube-proxy component label

### DIFF
--- a/v_6_0_0/files/k8s-resource/kube-proxy-ds.yaml
+++ b/v_6_0_0/files/k8s-resource/kube-proxy-ds.yaml
@@ -4,7 +4,6 @@ metadata:
   name: kube-proxy
   namespace: kube-system
   labels:
-    component: kube-proxy
     k8s-app: kube-proxy
     kubernetes.io/cluster-service: "true"
 spec:
@@ -18,7 +17,6 @@ spec:
   template:
     metadata:
       labels:
-        component: kube-proxy
         k8s-app: kube-proxy
         kubernetes.io/cluster-service: "true"
       annotations:


### PR DESCRIPTION
In an effort to have homogeneous labels, I removed this one as it is not used.
