### PR TITLE
Remove profiling from Controller Manager and Scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ versions are frozen. To freeze current version all files are copied to a new
 version directory, and  then changes are introduced.
 
 
-
 ## [Unreleased]
+
+- Disable profiling for Controller Manager and Scheduler
 
 ## [v6.0.2]
 

--- a/v_6_0_0/files/manifests/k8s-controller-manager.yaml
+++ b/v_6_0_0/files/manifests/k8s-controller-manager.yaml
@@ -29,6 +29,7 @@ spec:
     - --use-service-account-credentials=true
     - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
     - --feature-gates=TTLAfterFinished=true
+    - --profiling=false
     - --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
     - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-key.pem
     resources:

--- a/v_6_0_0/files/manifests/k8s-scheduler.yaml
+++ b/v_6_0_0/files/manifests/k8s-scheduler.yaml
@@ -21,6 +21,7 @@ spec:
     - kube-scheduler
     - --feature-gates=TTLAfterFinished=true{{ if eq .Cluster.Kubernetes.CloudProvider "aws" }},AttachVolumeLimit=false{{end}}
     - --config=/etc/kubernetes/config/scheduler.yaml
+    - --profiling=false
     - --v=2
     {{ if eq .Cluster.Kubernetes.CloudProvider "aws"  -}}
     env:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4813
Removes the debug profiling endpoint at /debug/pprof for Controller Manager and Scheduler

## Checklist

- [x] Update changelog in CHANGELOG.md.
