### PR TITLE
Remove IC performance improvements from OS provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+### Changed
+
+- Remove IC performance improvements from OS provisioning.
+
 ## [v6.0.3] 2020-04-16
 
 ### Added

--- a/v_6_0_0/files/conf/hardening.conf
+++ b/v_6_0_0/files/conf/hardening.conf
@@ -13,10 +13,6 @@ net.ipv6.conf.all.accept_redirects = 0
 net.ipv6.conf.default.accept_redirects = 0
 # Increased mmapfs because some applications, like ES, need higher limit to store data properly
 vm.max_map_count = 262144
-# Ingress controller performance improvements
-# See https://github.com/kubernetes/ingress-nginx/issues/1939
-net.core.somaxconn=32768
-net.ipv4.ip_local_port_range=1024 65535
 # Reserved to avoid conflicts with kube-apiserver, which allocates within this range
 net.ipv4.ip_local_reserved_ports=30000-32767
 net.ipv4.conf.all.rp_filter = 1


### PR DESCRIPTION
During hardening epic last year, these settings got moved from nginx init container to be set on host. Only recently we've uncovered this didn't actually work. For more info see https://github.com/giantswarm/nginx-ingress-controller-app/pull/55#issue-402580553

Init container got reinstated via https://github.com/giantswarm/nginx-ingress-controller-app/pull/61

Assumption is these settings are not needed by anything else and can be removed from the host.

## Checklist

- [x] Update changelog in CHANGELOG.md.
