### PR TITLE
Fix deployment labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+- Revert changes to deployment label selectors causing k8s-addons to fail.
+
 ## [v6.1.0] 2020-05-06
 
 ### Changed

--- a/files/k8s-resource/calico-all.yaml
+++ b/files/k8s-resource/calico-all.yaml
@@ -292,7 +292,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: calico-node
+      k8s-app: calico-node
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -541,7 +541,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: calico-kube-controllers
+      k8s-app: calico-kube-controllers
   strategy:
     type: Recreate
   template:

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -395,7 +395,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: calico-node
+      k8s-app: calico-node
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/files/k8s-resource/kube-proxy-ds.yaml
+++ b/files/k8s-resource/kube-proxy-ds.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-proxy
+      k8s-app: kube-proxy
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
I discovered during testing that the [recent label changes](https://github.com/giantswarm/k8scloudconfig/pull/695) cause k8s-addons to fail because the manifests are applied using `kubectl apply -f <file>` and `matchLabels` can't be changed on an existing deployment. We don't want to delete these deployments so I'm just reverting the changes.

## Checklist

- [x] Update changelog in CHANGELOG.md.
