### PR TITLE
'ha-masters-flattened'

### DIFF
--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -27,6 +27,9 @@ spec:
     {{ range .Hyperkube.Apiserver.Pod.CommandExtraArgs -}}
     - {{ . }}
     {{ end -}}
+    {{- if .MultiMasters.Enabled }}
+    - --apiserver-count=3
+    {{- end }}
     - --allow-privileged=true
     - --anonymous-auth=false
     - --insecure-port=0

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"text/template"
 
@@ -58,7 +59,9 @@ func NewCloudConfig(config CloudConfigConfig) (*CloudConfig, error) {
 	if config.Template == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Template must not be empty")
 	}
-
+	if config.Params.MultiMasters.Enabled && config.Params.MultiMasters.EtcdInitialCluster == "" {
+		config.Params.MultiMasters.EtcdInitialCluster = defaultEtcdMultiCluster(config.Params.BaseDomain)
+	}
 	c := &CloudConfig{
 		config:   "",
 		params:   config.Params,
@@ -111,4 +114,8 @@ func (c *CloudConfig) Base64() string {
 
 func (c *CloudConfig) String() string {
 	return c.config
+}
+
+func defaultEtcdMultiCluster(baseDomain string) string {
+	return fmt.Sprintf("etcd1=etcd1.%s,etcd2=etcd2.%s,etcd3=etcd3.%s", baseDomain, baseDomain, baseDomain)
 }

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -117,5 +117,5 @@ func (c *CloudConfig) String() string {
 }
 
 func defaultEtcdMultiCluster(baseDomain string) string {
-	return fmt.Sprintf("etcd1=etcd1.%s,etcd2=etcd2.%s,etcd3=etcd3.%s", baseDomain, baseDomain, baseDomain)
+	return fmt.Sprintf("etcd1=etcd1.%s:2380,etcd2=etcd2.%s:2380,etcd3=etcd3.%s:2380", baseDomain, baseDomain, baseDomain)
 }

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -35,7 +35,7 @@ func DefaultParams() Params {
 		EtcdPort:                  etcdPort,
 		ImagePullProgressDeadline: defaultImagePullProgressDeadline,
 		RegistryDomain:            "quay.io",
-		MultiMasters: MultiMastersSpec{
+		MultiMasters: MultiMasters{
 			Enabled:            false,
 			EtcdInitialCluster: "",
 		},

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -34,6 +34,10 @@ func DefaultParams() Params {
 		EtcdPort:                  etcdPort,
 		ImagePullProgressDeadline: defaultImagePullProgressDeadline,
 		RegistryDomain:            "quay.io",
+		MultiMasters: MultiMastersSpec{
+			Enabled:            false,
+			EtcdInitialCluster: "",
+		},
 		Versions: Versions{
 			Calico:   "1.0.0",
 			CRITools: "1.0.0",

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -204,11 +204,15 @@ systemd:
           --peer-key-file /etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }} \
-          --initial-advertise-peer-urls=https://127.0.0.1:2380 \
+          --initial-advertise-peer-urls=https://{{ .Cluster.Etcd.Domain }}:2380 \
           --listen-client-urls=https://0.0.0.0:2379 \
-          --listen-peer-urls=https://${DEFAULT_IPV4}:2380 \
+          --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
+          {{- if .MultiMasters.Enabled }}
+          --initial-cluster {{ .MultiMastersSpec.EtcdInitialCluster}} \
+          {{- else }}
           --initial-cluster etcd0=https://127.0.0.1:2380 \
+          {{- end }}
           --initial-cluster-state new \
           --data-dir=/var/lib/etcd \
           --enable-v2

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -46,7 +46,7 @@ type Params struct {
 	// cancelled if no progress has been made.
 	ImagePullProgressDeadline string
 	// Container images used in the cloud-config templates
-	Images Images
+	Images         Images
 	MultiMasters   MultiMasters
 	Node           v1alpha1.ClusterNode
 	RegistryDomain string

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -46,7 +46,9 @@ type Params struct {
 	// cancelled if no progress has been made.
 	ImagePullProgressDeadline string
 	// Container images used in the cloud-config templates
-	Images         Images
+	Images Images
+	// MultiMaster spec
+	MultiMasters   MultiMastersSpec
 	Node           v1alpha1.ClusterNode
 	RegistryDomain string
 	SSOPublicKey   string
@@ -116,6 +118,16 @@ type HyperkubePodHostMount struct {
 	Name     string
 	Path     string
 	ReadOnly bool
+}
+
+type MultiMastersSpec struct {
+	// If set to true, k8scloduconfig will render master template for cluster of 3 masters.
+	// Defaults to false.
+	Enabled bool
+	// Etcd initial cluster is config which define which etcd are members of the cluster.
+	// The format look like to this: `etcd0=https://10.1.1.1:2380,etcd1=https://10.1.1.2:2380,etcd2=https://10.1.1.3:2380`
+	// Where 10.1.1.1, 10.1.1.2, 10.1.1.3 can be either IP or DNS  of master machine where is etcd listening.
+	EtcdInitialCluster string
 }
 
 type FileMetadata struct {

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -48,7 +48,7 @@ type Params struct {
 	// Container images used in the cloud-config templates
 	Images Images
 	// MultiMaster spec
-	MultiMasters   MultiMastersSpec
+	MultiMasters   MultiMasters
 	Node           v1alpha1.ClusterNode
 	RegistryDomain string
 	SSOPublicKey   string

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -121,7 +121,7 @@ type HyperkubePodHostMount struct {
 }
 
 type MultiMasters struct {
-	// If set to true, k8scloduconfig will render master template for cluster of 3 masters.
+	// Enabled when set to true will cause rendering master template for cluster of 3 masters. Single master otherwise.
 	// Defaults to false.
 	Enabled bool
 	// EtcdInitialCluster is config which define which etcd are members of the cluster.

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -124,7 +124,7 @@ type MultiMasters struct {
 	// If set to true, k8scloduconfig will render master template for cluster of 3 masters.
 	// Defaults to false.
 	Enabled bool
-	// Etcd initial cluster is config which define which etcd are members of the cluster.
+	// EtcdInitialCluster is config which define which etcd are members of the cluster.
 	// The format look like to this: `etcd0=https://10.1.1.1:2380,etcd1=https://10.1.1.2:2380,etcd2=https://10.1.1.3:2380`
 	// Where 10.1.1.1, 10.1.1.2, 10.1.1.3 can be either IP or DNS  of master machine where is etcd listening.
 	EtcdInitialCluster string

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -47,7 +47,6 @@ type Params struct {
 	ImagePullProgressDeadline string
 	// Container images used in the cloud-config templates
 	Images Images
-	// MultiMaster spec
 	MultiMasters   MultiMasters
 	Node           v1alpha1.ClusterNode
 	RegistryDomain string

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -120,7 +120,7 @@ type HyperkubePodHostMount struct {
 	ReadOnly bool
 }
 
-type MultiMastersSpec struct {
+type MultiMasters struct {
 	// If set to true, k8scloduconfig will render master template for cluster of 3 masters.
 	// Defaults to false.
 	Enabled bool


### PR DESCRIPTION
For HA masters story

non-HA masters should stay the same and the only change is how the etcd cluster is bootstrapped when the HA masters flag is TRUE.


