### PR TITLE
add nodeName to the params

### DIFF
--- a/files/conf/calicoctl.cfg
+++ b/files/conf/calicoctl.cfg
@@ -2,7 +2,7 @@ apiVersion: projectcalico.org/v3
 kind: CalicoAPIConfig
 metadata:
 spec:
-  etcdEndpoints: https://{{.Cluster.Etcd.Domain}}:{{ .EtcdPort }}
+  etcdEndpoints: https://{{.Cluster.Etcd.Domain}}:{{ .Etcd.ClientPort }}
   etcdKeyFile: /etc/kubernetes/ssl/etcd/server-key.pem
   etcdCertFile: /etc/kubernetes/ssl/etcd/server-crt.pem
   etcdCACertFile: /etc/kubernetes/ssl/etcd/server-ca.pem

--- a/files/conf/etcd-alias
+++ b/files/conf/etcd-alias
@@ -1,5 +1,5 @@
 alias etcdctl="ETCDCTL_API=3 \
-    ETCDCTL_ENDPOINTS=https://{{.Cluster.Etcd.Domain}}:{{ .EtcdPort }} \
+    ETCDCTL_ENDPOINTS=https://{{.Cluster.Etcd.Domain}}:{{ .Etcd.ClientPort }} \
     ETCDCTL_CACERT=/etc/kubernetes/ssl/etcd/client-ca.pem \
     ETCDCTL_CERT=/etc/kubernetes/ssl/etcd/client-crt.pem \
     ETCDCTL_KEY=/etc/kubernetes/ssl/etcd/client-key.pem \

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -52,7 +52,7 @@ done
 
 # wait for etcd dns (return code 35 is bad certificate which is good enough here)
 while
-    curl "https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }}" -k 2>/dev/null >/dev/null
+    curl "https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }}" -k 2>/dev/null >/dev/null
     RET_CODE=$?
     [ "$RET_CODE" -ne "35" ]
 do

--- a/files/k8s-resource/calico-all.yaml
+++ b/files/k8s-resource/calico-all.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: kube-system
 data:
   # Configure this with the location of your etcd cluster.
-  etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }}"
+  etcd_endpoints: "https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }}"
 
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.

--- a/files/manifests/k8s-api-healthz.yaml
+++ b/files/manifests/k8s-api-healthz.yaml
@@ -18,6 +18,9 @@ spec:
       command:
         - /k8s-api-healthz
         - --api-endpoint="https://$(HOST_IP):443/healthz"
+        - --etcd-cert=/etc/kubernetes/ssl/etcd/server-crt.pem
+        - --etcd-key=/etc/kubernetes/ssl/etcd/server-key.pem
+        - --etcd-ca-cert=/etc/kubernetes/ssl/etcd/server-ca.pem
       image: {{ .Images.KubernetesAPIHealthz }}
       resources:
         requests:

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -27,7 +27,7 @@ spec:
     {{ range .Hyperkube.Apiserver.Pod.CommandExtraArgs -}}
     - {{ . }}
     {{ end -}}
-    {{- if .MultiMasters.Enabled }}
+    {{- if .Etcd.HighAvailability }}
     - --apiserver-count=3
     {{- end }}
     - --allow-privileged=true

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -118,5 +118,5 @@ func (c *CloudConfig) String() string {
 }
 
 func defaultEtcdMultiCluster(baseDomain string) string {
-	return fmt.Sprintf("etcd1=etcd1.%s:2380,etcd2=etcd2.%s:2380,etcd3=etcd3.%s:2380", baseDomain, baseDomain, baseDomain)
+	return fmt.Sprintf("etcd1=https://etcd1.%s:2380,etcd2=https://etcd2.%s:2380,etcd3=https://etcd3.%s:2380", baseDomain, baseDomain, baseDomain)
 }

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -38,6 +38,7 @@ func DefaultParams() Params {
 		MultiMasters: MultiMasters{
 			Enabled:            false,
 			EtcdInitialCluster: "",
+			MasterID:           0,
 		},
 		Versions: Versions{
 			Calico:   "1.0.0",

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -38,7 +38,7 @@ func DefaultParams() Params {
 		MultiMasters: MultiMasters{
 			Enabled:            false,
 			EtcdInitialCluster: "",
-			MasterID:           0,
+			MasterID:           1,
 		},
 		Versions: Versions{
 			Calico:   "1.0.0",

--- a/pkg/template/cloudconfig_test.go
+++ b/pkg/template/cloudconfig_test.go
@@ -43,7 +43,7 @@ func TestCloudConfig(t *testing.T) {
 		tc.params.Extension = nopExtension{}
 
 		if tc.customEtcdPort != 0 {
-			tc.params.EtcdPort = tc.customEtcdPort
+			tc.params.Etcd.ClientPort = tc.customEtcdPort
 		}
 
 		packagePath, err := GetPackagePath()
@@ -65,8 +65,8 @@ func TestCloudConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if cloudConfig.params.EtcdPort != tc.expectedEtcdPort {
-			t.Errorf("expected etcd port %q, got %q", tc.expectedEtcdPort, cloudConfig.params.EtcdPort)
+		if cloudConfig.params.Etcd.ClientPort != tc.expectedEtcdPort {
+			t.Errorf("expected etcd port %q, got %q", tc.expectedEtcdPort, cloudConfig.params.Etcd.ClientPort)
 		}
 		if err := cloudConfig.ExecuteTemplate(); err != nil {
 			t.Fatal(err)

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -210,6 +210,7 @@ systemd:
           --initial-cluster-token k8s-etcd-cluster \
           --initial-cluster {{ .Etcd.InitialCluster }} \
           --initial-cluster-state new \
+          --experimental-peer-skip-client-san-verification=true \
           --data-dir=/var/lib/etcd \
           --enable-v2
       [Install]

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -209,7 +209,7 @@ systemd:
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
           {{- if .MultiMasters.Enabled }}
-          --initial-cluster {{ .MultiMastersSpec.EtcdInitialCluster}} \
+          --initial-cluster {{ .MultiMasters.EtcdInitialCluster}} \
           {{- else }}
           --initial-cluster etcd0=https://127.0.0.1:2380 \
           {{- end }}

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -214,6 +214,7 @@ systemd:
           --initial-cluster-token k8s-etcd-cluster \
           {{- if .MultiMasters.Enabled }}
           --initial-cluster {{ .MultiMasters.EtcdInitialCluster }} \
+          --experimental-peer-skip-client-san-verification=true \
           {{- else }}
           --initial-cluster etcd{{ .MultiMasters.MasterID }}=https://127.0.0.1:2380 \
           {{- end }}

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -204,14 +204,18 @@ systemd:
           --peer-key-file /etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }} \
+          {(- if .MultiMasters.Enabled }}
+          --initial-advertise-peer-urls=https://etcd{{.MultiMasters.MasterID}}.{{ .BaseDomain }}:2380 \
+          {{- else }}
           --initial-advertise-peer-urls=https://{{ .Cluster.Etcd.Domain }}:2380 \
+          {{- end }}
           --listen-client-urls=https://0.0.0.0:2379 \
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
           {{- if .MultiMasters.Enabled }}
           --initial-cluster {{ .MultiMasters.EtcdInitialCluster}} \
           {{- else }}
-          --initial-cluster etcd0=https://127.0.0.1:2380 \
+          --initial-cluster etcd{{ .MultiMasters.MasterID }}=https://127.0.0.1:2380 \
           {{- end }}
           --initial-cluster-state new \
           --data-dir=/var/lib/etcd \

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -194,7 +194,7 @@ systemd:
           --name $NAME \
           $IMAGE \
           etcd \
-          --name etcd{{ .MultiMasters.MasterID }} \
+          --name {{ .Etcd.NodeName }} \
           --trusted-ca-file /etc/etcd/server-ca.pem \
           --cert-file /etc/etcd/server-crt.pem \
           --key-file /etc/etcd/server-key.pem\
@@ -203,21 +203,12 @@ systemd:
           --peer-cert-file /etc/etcd/server-crt.pem \
           --peer-key-file /etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
-          --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }} \
-          {{- if .MultiMasters.Enabled }}
-          --initial-advertise-peer-urls=https://etcd{{ .MultiMasters.MasterID }}.{{ .BaseDomain }}:2380 \
-          {{- else }}
-          --initial-advertise-peer-urls=https://{{ .Cluster.Etcd.Domain }}:2380 \
-          {{- end }}
+          --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }} \
+          --initial-advertise-peer-urls=https://{{ .Etcd.NodeName }}.{{ .BaseDomain }}:2380 \
           --listen-client-urls=https://0.0.0.0:2379 \
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
-          {{- if .MultiMasters.Enabled }}
-          --initial-cluster {{ .MultiMasters.EtcdInitialCluster }} \
-          --experimental-peer-skip-client-san-verification=true \
-          {{- else }}
-          --initial-cluster etcd{{ .MultiMasters.MasterID }}=https://127.0.0.1:2380 \
-          {{- end }}
+          --initial-cluster {{ .Etcd.InitialCluster }} \
           --initial-cluster-state new \
           --data-dir=/var/lib/etcd \
           --enable-v2

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -194,7 +194,7 @@ systemd:
           --name $NAME \
           $IMAGE \
           etcd \
-          --name etcd0 \
+          --name etcd{{ .MultiMasters.MasterID }} \
           --trusted-ca-file /etc/etcd/server-ca.pem \
           --cert-file /etc/etcd/server-crt.pem \
           --key-file /etc/etcd/server-key.pem\

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -204,8 +204,8 @@ systemd:
           --peer-key-file /etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .EtcdPort }} \
-          {(- if .MultiMasters.Enabled }}
-          --initial-advertise-peer-urls=https://etcd{{.MultiMasters.MasterID}}.{{ .BaseDomain }}:2380 \
+          {{- if .MultiMasters.Enabled }}
+          --initial-advertise-peer-urls=https://etcd{{ .MultiMasters.MasterID }}.{{ .BaseDomain }}:2380 \
           {{- else }}
           --initial-advertise-peer-urls=https://{{ .Cluster.Etcd.Domain }}:2380 \
           {{- end }}
@@ -213,7 +213,7 @@ systemd:
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
           {{- if .MultiMasters.Enabled }}
-          --initial-cluster {{ .MultiMasters.EtcdInitialCluster}} \
+          --initial-cluster {{ .MultiMasters.EtcdInitialCluster }} \
           {{- else }}
           --initial-cluster etcd{{ .MultiMasters.MasterID }}=https://127.0.0.1:2380 \
           {{- end }}

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -29,10 +29,7 @@ type Params struct {
 	// to hyperkube image commands. This allows to e.g. add cloud provider
 	// extensions.
 	Hyperkube Hyperkube
-	// EtcdPort allows the Etcd port to be specified.
-	// aws-operator sets this to the Etcd listening port so Calico on the
-	// worker nodes can access via a CNAME record to the master.
-	EtcdPort  int
+	Etcd      Etcd
 	Extension Extension
 	// ExtraManifests allows to specify extra Kubernetes manifests in
 	// /opt/k8s-addons script. The manifests are applied after calico is
@@ -47,7 +44,6 @@ type Params struct {
 	ImagePullProgressDeadline string
 	// Container images used in the cloud-config templates
 	Images         Images
-	MultiMasters   MultiMasters
 	Node           v1alpha1.ClusterNode
 	RegistryDomain string
 	SSOPublicKey   string
@@ -119,17 +115,21 @@ type HyperkubePodHostMount struct {
 	ReadOnly bool
 }
 
-type MultiMasters struct {
+type Etcd struct {
+	// ClientPort allows the port for clients to be specified.
+	// aws-operator sets this to the Etcd listening port so Calico on the
+	// worker nodes can access via a CNAME record to the master.
+	ClientPort int
 	// Enabled when set to true will cause rendering master template for cluster of 3 masters. Single master otherwise.
 	// Defaults to false.
-	Enabled bool
-	// EtcdInitialCluster is config which define which etcd are members of the cluster.
-	// The format look like to this: `etcd1=https://10.1.1.1:2380,etcd2=https://10.1.1.2:2380,etcd3=https://10.1.1.3:2380`
-	// Where 10.1.1.1, 10.1.1.2, 10.1.1.3 can be either IP or DNS  of master machine where is etcd listening.
-	EtcdInitialCluster string
-	// MasterID will be used for creating identification etcd name in the cluster.
-	// MasterID should have values to match EtcdInitialCluster settings.
-	MasterID int
+	HighAvailability bool
+	// InitialCluster is config which define which etcd are members of the cluster.
+	// The format should look like this: `etcd0=https://etcd1.example.com:2380,etcd1=https://etcd2.example.com:2380,etcd2=https://etcd3.example.com:2380`
+	// Where etcd1.example.com, etcd2.example.com, and etcd3.example.com can be either the IP or DNS of the master machine
+	// where is etcd listening.
+	InitialCluster string
+	// NodeName is the name of the current etcd cluster node.
+	NodeName string
 }
 
 type FileMetadata struct {

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -124,9 +124,12 @@ type MultiMasters struct {
 	// Defaults to false.
 	Enabled bool
 	// EtcdInitialCluster is config which define which etcd are members of the cluster.
-	// The format look like to this: `etcd0=https://10.1.1.1:2380,etcd1=https://10.1.1.2:2380,etcd2=https://10.1.1.3:2380`
+	// The format look like to this: `etcd1=https://10.1.1.1:2380,etcd2=https://10.1.1.2:2380,etcd3=https://10.1.1.3:2380`
 	// Where 10.1.1.1, 10.1.1.2, 10.1.1.3 can be either IP or DNS  of master machine where is etcd listening.
 	EtcdInitialCluster string
+	// MasterID will be used for creating identification etcd name in the cluster.
+	// MasterID should have values to match EtcdInitialCluster settings.
+	MasterID int
 }
 
 type FileMetadata struct {


### PR DESCRIPTION
included Thomas PR as well https://github.com/giantswarm/k8scloudconfig/pull/717

The etcd flag changes are to fix this error on single master clusters `May 13 22:45:26 master-h6s3z-9c95bc6d9-st2jl docker[16688]: 2020-05-13 22:45:26.705707 C | etcdmain: --initial-cluster has etcd0=https://127.0.0.1:2380 but missing from --initial-advertise-peer-urls=https://etcd.<redacted>.kvm.gigantic.io:2380 ("https://<redacted>:2380"(resolved from "https://etcd.<redacted>.kvm.gigantic.io:2380") != "https://127.0.0.1:2380"(resolved from "https://127.0.0.1:2380"))`