### PR TITLE
Drop index suffix for non-HA etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+### Added
+
+- Support for highly available etcd clusters.
+
 ## [v6.1.1] 2020-05-07
+
+### Fixed
 
 - Revert changes to deployment label selectors causing k8s-addons to fail.
 


### PR DESCRIPTION
After a little discussion, @calvix and I decided to drop the index suffix from the etcd node name for single master clusters. `etcd1` becomes `etcd`. This helps us with backwards compatibility in other operators where we currently create DNS records like `etcd.<domain>`.

## Checklist

- [x] Update changelog in CHANGELOG.md.
