### PR TITLE
Release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+## [v6.2.0] 2020-05-20
+
 ### Added
 
 - Support for highly available etcd clusters.
@@ -595,7 +597,8 @@ chart-operator).
 
 
 
-[Unreleased]: https://github.com/giantswarm/k8scloudconfig/compare/v6.1.1...HEAD
+[Unreleased]: https://github.com/giantswarm/k8scloudconfig/compare/v6.2.0...HEAD
+[v6.2.0]: https://github.com/giantswarm/k8scloudconfig/compare/v6.1.1...v6.2.0
 [v6.1.1]: https://github.com/giantswarm/k8scloudconfig/compare/v6.1.0...v6.1.1
 [v6.1.0]: https://github.com/giantswarm/k8scloudconfig/compare/v6.0.3...v6.1.0
 [v6.0.3]: https://github.com/giantswarm/k8scloudconfig/compare/v6.0.2...v6.0.3


### PR DESCRIPTION
Releasing this for the upcoming kvm-operator release with 1.17 support. @giantswarm/team-firecracker-pe and @giantswarm/team-celestial once you update operators to use this version, the 12.0.0 release with Kubernetes 1.17 should simply require changing the Kubernetes version in release `components` and 1.16 should continue to work like normal.

## Checklist

- [x] Update changelog in CHANGELOG.md.
