### PR TITLE
dont-delete-master-nodes-on-HA

### DIFF
--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -40,6 +40,7 @@ do
     done
 done
 
+{{- if not .Etcd.HighAvailability }}
 # check for other master and remove it
 THIS_MACHINE=$HOSTNAME
 for master in $(kubectl get nodes --no-headers=true --selector role=master | awk '{print $1}')
@@ -48,7 +49,7 @@ do
         kubectl delete node $master
     fi
 done
-
+{{- end -}}
 # wait for etcd dns (return code 35 is bad certificate which is good enough here)
 while
     curl "https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }}" -k 2>/dev/null >/dev/null

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -49,7 +49,8 @@ do
         kubectl delete node $master
     fi
 done
-{{- end -}}
+{{- end }}
+
 # wait for etcd dns (return code 35 is bad certificate which is good enough here)
 while
     curl "https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }}" -k 2>/dev/null >/dev/null


### PR DESCRIPTION
This old part of code is removing the other master nodes in case of node reboot. We don't need it for HA masters and AWS cloud provider should anyway clean old non-existing nodes.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
