### PR TITLE
Make calico 3.14 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+### Changed
+
+- RBAC permissions allowing calico node to get configmaps.
+
 ## [v6.2.0] 2020-05-20
 
 ### Added

--- a/files/k8s-resource/calico-all.yaml
+++ b/files/k8s-resource/calico-all.yaml
@@ -713,6 +713,12 @@ rules:
       - list
       # Used to discover Typhas.
       - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups: [""]
     resources:
       - nodes/status

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -594,6 +594,12 @@ rules:
       - list
       # Used to discover Typhas.
       - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups: [""]
     resources:
       - nodes/status


### PR DESCRIPTION
This is necessary for calico 3.14 - otherwise `calico node` simply crashloops. Upstream code that causes this:
https://github.com/projectcalico/node/blob/b1dc3c17492a763676471f7e5c532331971a4034/pkg/startup/startup.go#L138-L150

## Checklist

- [x] Update changelog in CHANGELOG.md.
