### PR TITLE
Fix regression in kubelet installation systemd unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+### Fixed
+
+- Regression in kubelet installation for 1.16 clusters.
+
 ## [v6.2.1] 2020-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ version directory, and  then changes are introduced.
 
 ### Fixed
 
-- Regression in kubelet installation for 1.16 clusters.
+- Regression in kubelet installation systemd unit for 1.16 clusters.
 
 ## [v6.2.1] 2020-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ version directory, and  then changes are introduced.
 
 ### Fixed
 
-- Regression in kubelet installation systemd unit for 1.16 clusters.
+- Fix regression in kubelet installation systemd unit for 1.16 clusters.
 
 ## [v6.2.1] 2020-05-26
 

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -43,7 +43,7 @@ func DefaultParams() Params {
 		Versions: Versions{
 			Calico:     "1.0.0",
 			CRITools:   "1.0.0",
-			Kubernetes: "v1.17.5",
+			Kubernetes: "v1.16.10",
 		},
 	}
 }


### PR DESCRIPTION
This library now checks the passed in kubernetes version to determine which binaries should be copied out of the `hyperkube` image in the `k8s-extract` service. When I set this to 1.17, this led previously-working operators to stop working when upgrading to k8scloudconfig v6.2.0+ because it wasn't necessary to pass in kubernetes version. To get the 1.17 compatibility, the version needs to be passed in (implemented in AWS and KVM already).

## Checklist

- [x] Update changelog in CHANGELOG.md.
