### PR TITLE
set-initial-cluster-state

### DIFF
--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -18,6 +18,9 @@ import (
 const (
 	defaultImagePullProgressDeadline = "1m"
 	etcdPort                         = 443
+
+	InitialClusterStateNew      = "new"
+	InitialClusterStateExisting = "existing"
 )
 
 type CloudConfigConfig struct {
@@ -37,8 +40,9 @@ func DefaultParams() Params {
 		ImagePullProgressDeadline: defaultImagePullProgressDeadline,
 		RegistryDomain:            "quay.io",
 		Etcd: Etcd{
-			ClientPort:       etcdPort,
-			HighAvailability: false,
+			ClientPort:          etcdPort,
+			HighAvailability:    false,
+			InitialClusterState: InitialClusterStateNew,
 		},
 		Versions: Versions{
 			Calico:     "1.0.0",

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -209,7 +209,7 @@ systemd:
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
           --initial-cluster {{ .Etcd.InitialCluster }} \
-          --initial-cluster-state new \
+          --initial-cluster-state {{ .Etcd.InitialClusterState }} \
           --experimental-peer-skip-client-san-verification=true \
           --data-dir=/var/lib/etcd \
           --enable-v2 \

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -119,6 +119,8 @@ type Etcd struct {
 	// Where etcd1.example.com, etcd2.example.com, and etcd3.example.com can be either the IP or DNS of the master machine
 	// where is etcd listening.
 	InitialCluster string
+	// Initial cluster state for ethe etcd cluster. Should have values either `new` or `existing`.
+	InitialClusterState string
 	// NodeName is the name of the current etcd cluster node.
 	NodeName string
 }

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -119,7 +119,7 @@ type Etcd struct {
 	// Where etcd1.example.com, etcd2.example.com, and etcd3.example.com can be either the IP or DNS of the master machine
 	// where is etcd listening.
 	InitialCluster string
-	// Initial cluster state for ethe etcd cluster. Should have values either `new` or `existing`.
+	// Initial cluster state for the etcd cluster. Should have values either `new` or `existing`.
 	InitialClusterState string
 	// NodeName is the name of the current etcd cluster node.
 	NodeName string


### PR DESCRIPTION
Another annoying change for the HA masters ( and hopefully last)

This is trying to solve an issue when we upgrade an etcd cluster from 1 to 3 nodes. In the current scenario, there is an issue that the first node is already bootstrapped and should serve as a source of truth for the two others. Unfortunately, with `new` flag they will create a separate working cluster and now there is a problem that they will respond healthy to the LBs and we practically have two k8s clusters running with separate data.

Setting the initial state to `existing` will prevent etcd from starting on the two other nodes and the migration process can help the other two nodes to join the cluster. 

maybe there are other ways how to disable etcd but this seems to be causing the least harm to any other cases.

In case you et the flag on already running cluster it will have no effect.

The goal is that operator should detect it is an updated cluster so it set the value properly. In case the operator doesn't know about it will stay the same with value `new` so it should be backward compatible.
