### PR TITLE
WIP: use env variables for ETCD clustering

### DIFF
--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -199,13 +199,13 @@ systemd:
           $IMAGE \
           etcd \
           --name ${ETCD_NAME} \
-          --trusted-ca-file /etc/etcd/server-ca.pem \
-          --cert-file /etc/etcd/server-crt.pem \
-          --key-file /etc/etcd/server-key.pem\
+          --trusted-ca-file=/etc/etcd/server-ca.pem \
+          --cert-file=/etc/etcd/server-crt.pem \
+          --key-file=/etc/etcd/server-key.pem\
           --client-cert-auth=true \
-          --peer-trusted-ca-file /etc/etcd/server-ca.pem \
-          --peer-cert-file /etc/etcd/server-crt.pem \
-          --peer-key-file /etc/etcd/server-key.pem \
+          --peer-trusted-ca-file=/etc/etcd/server-ca.pem \
+          --peer-cert-file=/etc/etcd/server-crt.pem \
+          --peer-key-file=/etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }} \
           --initial-advertise-peer-urls=http://0.0.0.0:2380 \

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -208,7 +208,7 @@ systemd:
           --peer-key-file /etc/etcd/server-key.pem \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }} \
-          --initial-advertise-peer-urls=http://${DEFAULT_IPV4}:2380 \
+          --initial-advertise-peer-urls=http://0.0.0.0:2380 \
           --listen-client-urls=https://0.0.0.0:2379 \
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token=k8s-etcd-cluster \

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -211,9 +211,9 @@ systemd:
           --initial-advertise-peer-urls=http://${DEFAULT_IPV4}:2380 \
           --listen-client-urls=https://0.0.0.0:2379 \
           --listen-peer-urls=https://0.0.0.0:2380 \
-          --initial-cluster-token k8s-etcd-cluster \
+          --initial-cluster-token=k8s-etcd-cluster \
           --initial-cluster=${ETCD_INITIAL_CLUSTER} \
-          --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE} \
+          --initial-cluster-state=${ETCD_INITIAL_CLUSTER_STATE} \
           --experimental-peer-skip-client-san-verification=true \
           --data-dir=/var/lib/etcd \
           --enable-v2 \

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -190,7 +190,6 @@ systemd:
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-crt.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
-      ExecStartPre=/bin/bash -c "while [ ! -f /etc/etcd-cluster-environment ]; do echo 'Waiting for /etc/etcd-cluster-environment to be written' && sleep 1; done"
       ExecStart=/usr/bin/docker run \
           -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
           -v /etc/kubernetes/ssl/etcd/:/etc/etcd \


### PR DESCRIPTION
WIP

@calvix I'd like to have your early feedback for this PR.

The goal of this PR is making the etcd3.service unit more easily configurable.
By default, it works out of the box as the current `k8scloudconfig` master is working (taking clustering setup data from the provider operator) but it can easily be extended by writing an environment file in `/etc/etcd-cluster-environment` to override the default values.

LMK what you think, thank you
