### PR TITLE
Expose kubelet health check endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ version directory, and  then changes are introduced.
 
 - Use templated registry domain value for docker registry mirror
 - Use `giantswarm/pause:3.1` container as pod infra container instead of default container, hosted on gcr.
+- Bind kubelet health check endpoint to all IPv4 addresses.
 
 ### Removed
 

--- a/files/config/kubelet-worker.yaml.tmpl
+++ b/files/config/kubelet-worker.yaml.tmpl
@@ -2,7 +2,7 @@ kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
 address: ${DEFAULT_IPV4}
 port: 10250
-healthzBindAddress: ${DEFAULT_IPV4}
+healthzBindAddress: "0.0.0.0"
 healthzPort: 10248
 clusterDNS:
   - {{.Cluster.Kubernetes.DNS.IP}}


### PR DESCRIPTION
## Checklist

- [X] Update changelog in CHANGELOG.md.


I'm testing rolling upgrades on Azure instances. For this, I need a health check endpoint so Azure can tell whether or not an instance is healthy. We thought using the kubelet health endpoint may be a good idea.
Azure makes requests to this endpoint using `localhost`, but we our current configuration we are binding the health endpoint just to the private IP address. With this PR, I'm binding to all IPv4 addresses so we can use both `localhost` and the private IP address.