### PR TITLE
Calico unify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ version directory, and  then changes are introduced.
 
 ## [Unreleased]
 
+## Changed
+
+- Upgrade calico to 3.14.1
+- Slightly changed the configuration interface for Calico
+
 ## [6.2.6] - 2020-06-19
 
 ### Removed

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -90,14 +90,13 @@ kubectl delete pods -l app.kubernetes.io/name=kube-proxy -n kube-system
 {{ if .CalicoPolicyOnly -}}
 ## Apply Calico with network policy features only
 CNI_FILE="calico-policy-only.yaml"
+{{ if .EnableAWSCNI -}}
+## Apply AWS VPC CNI
+CNI_FILE="${CNI_FILE} aws-cni.yaml"
+{{ end -}}
 {{ else -}}
 ## Apply Calico with all its components
 CNI_FILE="calico-all.yaml"
-{{ end -}}
-
-{{ if .EnableAWSCNI -}}
-## Apply AWS VPC CNI and Calico for ensuring network policies (only on AWS)
-CNI_FILE="$CNI_FILE aws-cni.yaml"
 {{ end -}}
 
 for manifest in ${CNI_FILE}

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -87,14 +87,17 @@ echo "kube-proxy successfully installed"
 # restart ds to apply config from configmap
 kubectl delete pods -l app.kubernetes.io/name=kube-proxy -n kube-system
 
-{{ if not .DisableCalico -}}
-
-{{ if .EnableAWSCNI -}}
-## Apply AWS VPC CNI and Calico for ensuring network policies (only on AWS)
-CNI_FILE="aws-cni.yaml calico-policy-only.yaml"
+{{ if .CalicoPolicyOnly -}}
+## Apply Calico with network policy features only
+CNI_FILE="calico-policy-only.yaml"
 {{ else -}}
 ## Apply Calico with all its components
 CNI_FILE="calico-all.yaml"
+{{ end -}}
+
+{{ if .EnableAWSCNI -}}
+## Apply AWS VPC CNI and Calico for ensuring network policies (only on AWS)
+CNI_FILE="$CNI_FILE aws-cni.yaml"
 {{ end -}}
 
 for manifest in ${CNI_FILE}
@@ -115,8 +118,6 @@ kubectl -n kube-system -l app.kubernetes.io/name=aws-node wait --for=condition=R
 
 echo "Waiting for calico-node to be ready..."
 kubectl -n kube-system -l app.kubernetes.io/name=calico-node wait --for=condition=Ready --timeout=10m pods
-
-{{ end -}}
 
 # apply default storage class
 if [ -f /srv/default-storage-class.yaml ]; then

--- a/files/config/kube-proxy.yaml
+++ b/files/config/kube-proxy.yaml
@@ -3,7 +3,7 @@ clientConnection:
   kubeconfig: /etc/kubernetes/config/proxy-kubeconfig.yaml
 kind: KubeProxyConfiguration
 mode: iptables
-{{- if and (and (ne .Cluster.Kubernetes.CloudProvider "aws") (ne .Cluster.Kubernetes.CloudProvider "azure")) (not .DisableCalico) }}
+{{- if not .CalicoPolicyOnly }}
 clusterCIDR: {{ .Cluster.Calico.Subnet }}/{{ .Cluster.Calico.CIDR }}
 {{- end }}
 {{- if .Cluster.Kubernetes.NetworkSetup.KubeProxy.ConntrackMaxPerCore }}

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -424,7 +424,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .Images.CalicoCNI }}
+          image: {{ .Images.CalicoNode }}
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -411,6 +411,13 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,ecs"
+            {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within --cluster-cidr.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ .CalicoCIDR }}"
+            {{- end }}
             # Disable file logging so kubectl logs works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -410,11 +410,11 @@ spec:
                   fieldPath: spec.nodeName
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
-              value: none
+              value: "none"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,ecs"
-            # Disable file logging so `kubectl logs` works.
+            # Disable file logging so kubectl logs works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
@@ -447,7 +447,6 @@ spec:
               command:
                 - /bin/calico-node
                 - -felix-live
-                - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -456,23 +455,17 @@ spec:
               command:
                 - /bin/calico-node
                 - -felix-ready
-                - -bird-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
-              readOnly: false
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-            - name: policysync
-              mountPath: /var/run/nodeagent
       volumes:
         # Used by calico-node.
         - name: lib-modules
@@ -484,10 +477,6 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
-        - name: xtables-lock
-          hostPath:
-            path: /run/xtables.lock
-            type: FileOrCreate
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -501,11 +490,6 @@ spec:
         - name: host-local-net-dir
           hostPath:
             path: /var/lib/cni/networks
-        # Used to create per-pod Unix Domain Sockets
-        - name: policysync
-          hostPath:
-            type: DirectoryOrCreate
-            path: /var/run/nodeagent
         # Used to install Flex Volume Driver
         - name: flexvol-driver-host
           hostPath:

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -400,6 +400,12 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
+            # Typha support: controlled by the ConfigMap.
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: typha_service_name
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -307,6 +307,7 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
+    giantswarm.io/service-type: managed
     k8s-app: calico-node
 spec:
   selector:
@@ -319,6 +320,7 @@ spec:
   template:
     metadata:
       labels:
+        giantswarm.io/service-type: managed
         k8s-app: calico-node
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
@@ -371,7 +373,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.14.1
+          image: {{ .Images.CalicoCNI }}
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -422,7 +424,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.14.1
+          image: {{ .Images.CalicoCNI }}
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -381,15 +381,6 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
-        # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
-        # to communicate with Felix over the Policy Sync API.
-        - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.14.1
-          volumeMounts:
-            - name: flexvol-driver-host
-              mountPath: /host/driver
-          securityContext:
-            privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -490,17 +481,6 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
-        # Mount in the directory for host-local IPAM allocations. This is
-        # used when upgrading from host-local to calico-ipam, and can be removed
-        # if not using the upgrade-ipam init container.
-        - name: host-local-net-dir
-          hostPath:
-            path: /var/lib/cni/networks
-        # Used to install Flex Volume Driver
-        - name: flexvol-driver-host
-          hostPath:
-            type: DirectoryOrCreate
-            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
 ---
 
 apiVersion: v1

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -367,12 +367,6 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: cni_network_config
-            # CNI MTU Config variable
-            - name: CNI_MTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -408,41 +408,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Choose the backend to use.
+            # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
+              value: none
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
-              value: "k8s,bgp"
-            # Auto-detect the BGP IP address.
-            - name: IP
-              value: "autodetect"
-            # Enable IPIP
-            - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
-            # Enable or Disable VXLAN on the default IP pool.
-            - name: CALICO_IPV4POOL_VXLAN
-              value: "Never"
-            # Set MTU for tunnel device used if ipip is enabled
-            - name: FELIX_IPINIPMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the VXLAN tunnel device.
-            - name: FELIX_VXLANMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-            # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within `--cluster-cidr`.
-            # - name: CALICO_IPV4POOL_CIDR
-            #   value: "192.168.0.0/16"
+              value: "k8s,ecs"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -347,6 +347,8 @@ spec:
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
       initContainers:
+        # This container installs the CNI binaries
+        # and CNI network config file on each node.
         - name: install-cni
           image: {{ .Images.CalicoCNI }}
           command: ["/install-cni.sh"]

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -411,12 +411,12 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,ecs"
-            {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
+            {{- if ne .CalicoIPV4PoolCIDR "" }}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within --cluster-cidr.
             - name: CALICO_IPV4POOL_CIDR
-              value: "{{ .CalicoCIDR }}"
+              value: "{{ .CalicoIPV4PoolCIDR }}"
             {{- end }}
             # Disable file logging so kubectl logs works.
             - name: CALICO_DISABLE_FILE_LOGGING

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -347,31 +347,6 @@ spec:
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
       initContainers:
-        # This container performs upgrade from host-local IPAM to calico-ipam.
-        # It can be deleted if this is a fresh installation, or if you have already
-        # upgraded to use calico-ipam.
-        - name: upgrade-ipam
-          image: calico/cni:v3.14.1
-          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
-          env:
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-          volumeMounts:
-            - mountPath: /var/lib/cni/networks
-              name: host-local-net-dir
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-          securityContext:
-            privileged: true
-        # This container installs the CNI binaries
-        # and CNI network config file on each node.
         - name: install-cni
           image: {{ .Images.CalicoCNI }}
           command: ["/install-cni.sh"]

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -5,12 +5,12 @@
 #  - Made install-cni initContainer.
 #  - Added 'priorityClassName: system-cluster-critical' to calico daemonset and calico typha deployment.
 #
-# Calico Version v3.10.1
-# https://docs.projectcalico.org/v3.10/release-notes/
+# Calico Version v3.14.1
+# https://docs.projectcalico.org/release-notes/#v3141
 # This manifest includes the following component versions:
-#   calico/node:v3.10.1
-#   calico/cni:v3.10.1
-#   calico/typha:v3.10.1
+#   calico/node:v3.14.1
+#   calico/cni:v3.14.1
+#   calico/typha:v3.14.1
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -52,6 +52,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }
@@ -67,7 +71,6 @@ metadata:
   name: calico-typha
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: calico-typha
     k8s-app: calico-typha
 spec:
   ports:
@@ -76,7 +79,7 @@ spec:
       targetPort: calico-typha
       name: calico-typha
   selector:
-    app.kubernetes.io/name: calico-typha
+    k8s-app: calico-typha
 
 ---
 
@@ -229,6 +232,8 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+    shortNames:
+      - gnp
 
 ---
 
@@ -280,15 +285,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: networksets.crd.projectcalico.org
+  name: bgppeers.crd.projectcalico.org
 spec:
-  scope: Namespaced
+  scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: NetworkSet
-    plural: networksets
-    singular: networkset
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
 
 ---
 
@@ -302,8 +307,6 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: calico-node
-    giantswarm.io/service-type: managed
     k8s-app: calico-node
 spec:
   selector:
@@ -316,8 +319,6 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: calico-node
-        giantswarm.io/service-type: managed
         k8s-app: calico-node
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
@@ -344,10 +345,33 @@ spec:
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
       initContainers:
+        # This container performs upgrade from host-local IPAM to calico-ipam.
+        # It can be deleted if this is a fresh installation, or if you have already
+        # upgraded to use calico-ipam.
+        - name: upgrade-ipam
+          image: calico/cni:v3.14.1
+          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+          volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          securityContext:
+            privileged: true
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .Images.CalicoCNI }}
+          image: calico/cni:v3.14.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -364,6 +388,12 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: cni_network_config
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"
@@ -376,22 +406,27 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+          securityContext:
+            privileged: true
+        # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+        # to communicate with Felix over the Policy Sync API.
+        - name: flexvol-driver
+          image: calico/pod2daemon-flexvol:v3.14.1
+          volumeMounts:
+            - name: flexvol-driver-host
+              mountPath: /host/driver
+          securityContext:
+            privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .Images.CalicoNode }}
+          image: calico/node:v3.14.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Typha support: controlled by the ConfigMap.
-            - name: FELIX_TYPHAK8SSERVICENAME
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: typha_service_name
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -400,13 +435,42 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Don't enable BGP.
+            # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND
-              value: "none"
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
-              value: "k8s,ecs"
-            # Disable file logging so kubectl logs works.
+              value: "k8s,bgp"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Enable or Disable VXLAN on the default IP pool.
+            - name: CALICO_IPV4POOL_VXLAN
+              value: "Never"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Set MTU for the VXLAN tunnel device.
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # - name: CALICO_IPV4POOL_CIDR
+            #   value: "192.168.0.0/16"
+            # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
@@ -417,8 +481,10 @@ spec:
               value: "false"
             - name: FELIX_IPTABLESMANGLEALLOWACTION
               value: Return
+            {{- if eq .Cluster.Kubernetes.CloudProvider "aws" }}
             - name: FELIX_INTERFACEPREFIX
               value: eni
+            {{- end }}
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
@@ -437,6 +503,7 @@ spec:
               command:
                 - /bin/calico-node
                 - -felix-live
+                - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -445,17 +512,23 @@ spec:
               command:
                 - /bin/calico-node
                 - -felix-ready
+                - -bird-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
+            - name: policysync
+              mountPath: /var/run/nodeagent
       volumes:
         # Used by calico-node.
         - name: lib-modules
@@ -467,6 +540,10 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -474,6 +551,22 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
+        # Used to create per-pod Unix Domain Sockets
+        - name: policysync
+          hostPath:
+            type: DirectoryOrCreate
+            path: /var/run/nodeagent
+        # Used to install Flex Volume Driver
+        - name: flexvol-driver-host
+          hostPath:
+            type: DirectoryOrCreate
+            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
 ---
 
 apiVersion: v1
@@ -592,6 +685,7 @@ rules:
     verbs:
       - create
       - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities
@@ -603,6 +697,24 @@ rules:
       - create
       - update
       - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -411,13 +411,6 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,ecs"
-            {{- if ne .CalicoIPV4PoolCIDR "" }}
-            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-            # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within --cluster-cidr.
-            - name: CALICO_IPV4POOL_CIDR
-              value: "{{ .CalicoIPV4PoolCIDR }}"
-            {{- end }}
             # Disable file logging so kubectl logs works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -47,7 +47,7 @@ func DefaultParams() Params {
 		Versions: Versions{
 			Calico:     "1.0.0",
 			CRITools:   "1.0.0",
-			Kubernetes: "v1.16.11",
+			Kubernetes: "v1.16.10",
 		},
 	}
 }

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -47,7 +47,7 @@ func DefaultParams() Params {
 		Versions: Versions{
 			Calico:     "1.0.0",
 			CRITools:   "1.0.0",
-			Kubernetes: "v1.16.10",
+			Kubernetes: "v1.16.11",
 		},
 	}
 }

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -407,7 +407,7 @@ storage:
         source: "data:text/plain;base64,{{ index .Files "conf/trusted-user-ca-keys.pem" }}"
 
     {{- if .CalicoPolicyOnly }}
-	- path: /srv/calico-policy-only.yaml
+    - path: /srv/calico-policy-only.yaml
       filesystem: root
       mode: 0644
       contents:

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -406,14 +406,8 @@ storage:
       contents:
         source: "data:text/plain;base64,{{ index .Files "conf/trusted-user-ca-keys.pem" }}"
 
-    {{- if not .DisableCalico }}
-    {{- if .EnableAWSCNI }}
-    - path: /srv/aws-cni.yaml
-      filesystem: root
-      mode: 0644
-      contents:
-        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/aws-cni.yaml" }}"
-    - path: /srv/calico-policy-only.yaml
+    {{- if .CalicoPolicyOnly }}
+	- path: /srv/calico-policy-only.yaml
       filesystem: root
       mode: 0644
       contents:
@@ -425,6 +419,13 @@ storage:
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/calico-all.yaml" }}"
     {{- end }}
+
+    {{- if .EnableAWSCNI }}
+    - path: /srv/aws-cni.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "k8s-resource/aws-cni.yaml" }}"
     {{- end }}
 
     {{- if not .DisableIngressControllerService }}

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -17,6 +17,10 @@ type Params struct {
 	EnableAWSCNI bool
 	// CalicoPolicyOnly flag. When set to true will deploy calico for network policies only.
 	CalicoPolicyOnly bool
+	// The default IPv4 pool to create on startup if none exists. Pod IPs will be
+	// chosen from this range. Changing this value after installation will have
+	// no effect. This should fall within --cluster-cidr.
+	CalicoIPV4PoolCIDR string
 	// DisableEncryptionAtREST flag. When set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -15,9 +15,8 @@ type Params struct {
 	// EnableAWSCNI flag. When set to true will use AWS CNI for pod networking
 	// and Calico only for network policies.
 	EnableAWSCNI bool
-	// DisableCalico flag. When set removes all calico related Kubernetes
-	// manifests from the cloud config together with their initialization.
-	DisableCalico bool
+	// CalicoPolicyOnly flag. When set to true will deploy calico for network policies only.
+	CalicoPolicyOnly bool
 	// DisableEncryptionAtREST flag. When set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -17,10 +17,6 @@ type Params struct {
 	EnableAWSCNI bool
 	// CalicoPolicyOnly flag. When set to true will deploy calico for network policies only.
 	CalicoPolicyOnly bool
-	// The default IPv4 pool to create on startup if none exists. Pod IPs will be
-	// chosen from this range. Changing this value after installation will have
-	// no effect. This should fall within --cluster-cidr.
-	CalicoIPV4PoolCIDR string
 	// DisableEncryptionAtREST flag. When set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11307

The goal of this PR is to upgrade `calico` to the latest release and to avoid having a separate calico manifest between AWS and Azure.

