### PR TITLE
template: validate Images registry domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ version directory, and  then changes are introduced.
 ### Changed
 
 - Change `kube-apiserver` image to include certs.
+- Fail if all images do not have the same registry.
 
 ## [6.3.0] - 2020-06-22
 

--- a/pkg/template/cloudconfig_test.go
+++ b/pkg/template/cloudconfig_test.go
@@ -56,6 +56,7 @@ func TestCloudConfig(t *testing.T) {
 			t.Errorf("failed to render ignition files, %v:", err)
 		}
 		tc.params.Files = files
+		tc.params.Images = BuildImages(tc.params.RegistryDomain, Versions{})
 
 		c.Params = tc.params
 		c.Template = tc.template

--- a/pkg/template/release.go
+++ b/pkg/template/release.go
@@ -1,10 +1,13 @@
 package template
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
 )
 
 func BuildImages(registryDomain string, versions Versions) Images {
@@ -70,4 +73,27 @@ func findComponent(releaseComponents []v1alpha1.ReleaseSpecComponent, name strin
 		}
 	}
 	return nil, componentNotFoundError
+}
+
+func validateImagesRegsitry(images Images, registry string) error {
+	data, err := json.Marshal(images)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var m map[string]string
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for k, image := range m {
+		split := strings.Split(image, "/")
+		r := split[0]
+		if r != registry {
+			return microerror.Maskf(invalidConfigError, "%T.%s image %#q should have registry set to %#q", images, k, image, registry)
+		}
+	}
+
+	return nil
 }

--- a/pkg/template/release_test.go
+++ b/pkg/template/release_test.go
@@ -1,0 +1,114 @@
+package template
+
+import (
+	"strconv"
+	"testing"
+)
+
+func Test_validateImagesRegsitry(t *testing.T) {
+	testCases := []struct {
+		name          string
+		inputImages   Images
+		inputRegistry string
+		errorMatcher  func(err error) bool
+	}{
+		{
+			name:          "case 0: ok",
+			inputImages:   BuildImages("docker.io", Versions{}),
+			inputRegistry: "docker.io",
+			errorMatcher:  nil,
+		},
+		{
+			name:          "case 1: different registry",
+			inputImages:   BuildImages("docker.io", Versions{}),
+			inputRegistry: "quay.io",
+			errorMatcher:  IsInvalidConfig,
+		},
+		{
+			name:          "case 2: empty Images",
+			inputImages:   Images{},
+			inputRegistry: "quay.io",
+			errorMatcher:  IsInvalidConfig,
+		},
+		{
+			name: "case 3: manually set images",
+			inputImages: Images{
+				CalicoCNI:                    "docker.io/giantswarm/image:1.2.3",
+				CalicoKubeControllers:        "docker.io/giantswarm/image:1.2.3",
+				CalicoNode:                   "docker.io/giantswarm/image:1.2.3",
+				Etcd:                         "docker.io/giantswarm/image:1.2.3",
+				Hyperkube:                    "docker.io/giantswarm/image:1.2.3",
+				KubeApiserver:                "docker.io/giantswarm/image:1.2.3",
+				KubeControllerManager:        "docker.io/giantswarm/image:1.2.3",
+				KubeScheduler:                "docker.io/giantswarm/image:1.2.3",
+				KubeProxy:                    "docker.io/giantswarm/image:1.2.3",
+				KubernetesAPIHealthz:         "docker.io/giantswarm/image:1.2.3",
+				KubernetesNetworkSetupDocker: "docker.io/giantswarm/image:1.2.3",
+				Pause:                        "docker.io/giantswarm/image:1.2.3",
+			},
+			inputRegistry: "docker.io",
+			errorMatcher:  nil,
+		},
+		{
+			name: "case 4: manually set images - one is wrong",
+			inputImages: Images{
+				CalicoCNI:                    "docker.io/giantswarm/image:1.2.3",
+				CalicoKubeControllers:        "docker.io/giantswarm/image:1.2.3",
+				CalicoNode:                   "docker.io/giantswarm/image:1.2.3",
+				Etcd:                         "docker.io/giantswarm/image:1.2.3",
+				Hyperkube:                    "docker.io/giantswarm/image:1.2.3",
+				KubeApiserver:                "docker.io/giantswarm/image:1.2.3",
+				KubeControllerManager:        "quay.io/giantswarm/image:1.2.3",
+				KubeScheduler:                "docker.io/giantswarm/image:1.2.3",
+				KubeProxy:                    "docker.io/giantswarm/image:1.2.3",
+				KubernetesAPIHealthz:         "docker.io/giantswarm/image:1.2.3",
+				KubernetesNetworkSetupDocker: "docker.io/giantswarm/image:1.2.3",
+				Pause:                        "docker.io/giantswarm/image:1.2.3",
+			},
+			inputRegistry: "docker.io",
+			errorMatcher:  IsInvalidConfig,
+		},
+		{
+			name: "case 5: manually set images - one is empty",
+			inputImages: Images{
+				CalicoCNI:                    "docker.io/giantswarm/image:1.2.3",
+				CalicoKubeControllers:        "docker.io/giantswarm/image:1.2.3",
+				CalicoNode:                   "",
+				Etcd:                         "docker.io/giantswarm/image:1.2.3",
+				Hyperkube:                    "docker.io/giantswarm/image:1.2.3",
+				KubeApiserver:                "docker.io/giantswarm/image:1.2.3",
+				KubeControllerManager:        "docker.io/giantswarm/image:1.2.3",
+				KubeScheduler:                "docker.io/giantswarm/image:1.2.3",
+				KubeProxy:                    "docker.io/giantswarm/image:1.2.3",
+				KubernetesAPIHealthz:         "docker.io/giantswarm/image:1.2.3",
+				KubernetesNetworkSetupDocker: "docker.io/giantswarm/image:1.2.3",
+				Pause:                        "docker.io/giantswarm/image:1.2.3",
+			},
+			inputRegistry: "docker.io",
+			errorMatcher:  IsInvalidConfig,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			err := validateImagesRegsitry(tc.inputImages, tc.inputRegistry)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
 )
 
 type Params struct {
@@ -50,6 +51,13 @@ type Params struct {
 }
 
 func (p *Params) Validate() error {
+	if p.RegistryDomain == "" {
+		return microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", p)
+	}
+	if err := validateImagesRegsitry(p.Images, p.RegistryDomain); err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11736

This change ensures that all images in `Parameters.Images` has the same
registry domain as set in `Parameters.RegistryDomain`.


## Checklist

- [x] Update changelog in CHANGELOG.md.