### PR TITLE
remove-pv-limit-aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Removed PV node limits for AWS as the feature gate is no longer supported in 1.17+.
 
 ## [7.0.1] - 2020-07-20
 

--- a/files/manifests/k8s-scheduler.yaml
+++ b/files/manifests/k8s-scheduler.yaml
@@ -18,15 +18,10 @@ spec:
     image: {{ .Images.KubeScheduler }}
     command:
     - kube-scheduler
-    - --feature-gates=TTLAfterFinished=true{{ if eq .Cluster.Kubernetes.CloudProvider "aws" }},AttachVolumeLimit=false{{end}}
+    - --feature-gates=TTLAfterFinished=true
     - --config=/etc/kubernetes/config/scheduler.yaml
     - --profiling=false
     - --v=2
-    {{ if eq .Cluster.Kubernetes.CloudProvider "aws"  -}}
-    env:
-     - name: KUBE_MAX_PD_VOLS
-       value: "20"
-    {{ end -}}
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.


The feature gate is a little bit cryptic but we disabled it to set custom PV node limits, as when the feature gate is enabled they will use some magic method to calculate the PV limit which is wrong. But unfortunately from  k8s version 1.17 the feature gate cannot be disabled.

There is nothing we can do atm, the customer is aware as well as SEs, the only solution is to move to CSI storage manager for EBS where limits can be applied again.