### PR TITLE
set-etcd-data-dir-permissions-to-0700

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change etcd data dir permission to `0700` to comply with etcd 3.10.4 requirements.
+
 ## [7.0.2] - 2020-07-22
 ### Removed
 - Removed PV node limits for AWS as the feature gate is no longer supported in 1.17+.

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -185,6 +185,7 @@ systemd:
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-ca.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-crt.pem to be written' && sleep 1; done"
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/etcd/server-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/etcd/server-key.pem to be written' && sleep 1; done"
+      ExecStartPre=/bin/bash -c "chmod 0700 /var/lib/etcd/"
       ExecStart=/usr/bin/docker run \
           -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
           -v /etc/kubernetes/ssl/etcd/:/etc/etcd \


### PR DESCRIPTION
etcd 3.4.10 needs 0700 permission on the data dir
https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.4.md

chmod is the only way as we need to ensure older clusters will have this fixed as well.