### PR TITLE
Fix: wrong max pod size for instance-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
 - Adjust number of host network pods on worker node for aws-cni
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust number of host network pods on worker node for aws-cni
+
 ## [7.0.4] - 2020-07-29
 
 - Adjust MAX_PODS for master and worker nodes to max IP's per ENI when using aws-cni

--- a/files/conf/setup-kubelet-environment
+++ b/files/conf/setup-kubelet-environment
@@ -23,7 +23,7 @@ else
   # 1 ENI for the node
   reserved_eni=1
   # Only counting daemonsets, as they are mandatory in all nodes
-  hostnetwork_pods=5
+  hostnetwork_pods=6
 fi
 
 # Formula for max amount of pods in AWS CNI is (enis-$reserved_enis)*(ips_eni-1)+$host_network_pods


### PR DESCRIPTION
According to the number we have from our conformance tests we need to adjust the number of hostnetwork pods on worker again

Pods with HostNetwork on the worker node:

aws-node-cxzz7 
calico-node-g5nz6 
cert-exporter-498x7 
kiam-agent-qkld4 
kube-proxy-zt67p 
node-exporter-n66tv

## Checklist

- [x] Update changelog in CHANGELOG.md.