### PR TITLE
Fix etcdctl alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add monitoring annotations `prometheus.io/*` and `giantswarm.io/monitoring*` to kube-proxy, k8s-scheduler, k8s-controller-manager and calico.
 
+### Changed
+
+- Changed the path of the ETCD certificate files used in the etcdctl alias.
+
 ## [8.0.0] - 2020-08-11
 
 ### Added

--- a/files/conf/etcd-alias
+++ b/files/conf/etcd-alias
@@ -1,6 +1,6 @@
 alias etcdctl="ETCDCTL_API=3 \
     ETCDCTL_ENDPOINTS=https://{{.Cluster.Etcd.Domain}}:{{ .Etcd.ClientPort }} \
-    ETCDCTL_CACERT=/etc/kubernetes/ssl/etcd/client-ca.pem \
-    ETCDCTL_CERT=/etc/kubernetes/ssl/etcd/client-crt.pem \
-    ETCDCTL_KEY=/etc/kubernetes/ssl/etcd/client-key.pem \
+    ETCDCTL_CACERT=/etc/kubernetes/ssl/etcd/server-ca.pem \
+    ETCDCTL_CERT=/etc/kubernetes/ssl/etcd/server-crt.pem \
+    ETCDCTL_KEY=/etc/kubernetes/ssl/etcd/server-key.pem \
     etcdctl"


### PR DESCRIPTION
The `etcdctl` alias has a reference to some TLS certificate files that are not available any more in our tenant clusters.

This PR changes those references to an existing file to restore the etcdctl feature.