### PR TITLE
Expose etcd variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add monitoring annotations `prometheus.io/*` and `giantswarm.io/monitoring*` to kube-proxy, k8s-scheduler, k8s-controller-manager and calico.
 
+### Changed
+
+- Exposed some of the etcd3.service systemd unit settings via environment variables to make customizations in the configuration easier. 
+
 ## [8.0.0] - 2020-08-11
 
 ### Added

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -178,6 +178,12 @@ systemd:
       Slice=kubereserved.slice
       Environment=IMAGE={{ .Images.Etcd }}
       Environment=NAME=%p.service
+      Environment=ETCD_NAME={{ .Etcd.NodeName }}
+      Environment=ETCD_INITIAL_CLUSTER={{ .Etcd.InitialCluster }}
+      Environment=ETCD_INITIAL_CLUSTER_STATE={{ .Etcd.InitialClusterState }}
+      Environment=ETCD_PEER_CA_PATH=/etc/etcd/server-ca.pem
+      Environment=ETCD_PEER_CERT_PATH=/etc/etcd/server-crt.pem
+      Environment=ETCD_PEER_KEY_PATH=/etc/etcd/server-key.pem
       EnvironmentFile=/etc/network-environment
       ExecStartPre=-/usr/bin/docker stop  $NAME
       ExecStartPre=-/usr/bin/docker rm  $NAME
@@ -194,22 +200,22 @@ systemd:
           --name $NAME \
           $IMAGE \
           etcd \
-          --name {{ .Etcd.NodeName }} \
+          --name ${ETCD_NAME} \
           --trusted-ca-file /etc/etcd/server-ca.pem \
           --cert-file /etc/etcd/server-crt.pem \
           --key-file /etc/etcd/server-key.pem\
           --client-cert-auth=true \
-          --peer-trusted-ca-file /etc/etcd/server-ca.pem \
-          --peer-cert-file /etc/etcd/server-crt.pem \
-          --peer-key-file /etc/etcd/server-key.pem \
+          --peer-trusted-ca-file ${ETCD_PEER_CA_PATH} \
+          --peer-cert-file ${ETCD_PEER_CERT_PATH} \
+          --peer-key-file ${ETCD_PEER_KEY_PATH} \
           --peer-client-cert-auth=true \
           --advertise-client-urls=https://{{ .Cluster.Etcd.Domain }}:{{ .Etcd.ClientPort }} \
-          --initial-advertise-peer-urls=https://{{ .Etcd.NodeName }}.{{ .BaseDomain }}:2380 \
+          --initial-advertise-peer-urls=https://${ETCD_NAME}.{{ .BaseDomain }}:2380 \
           --listen-client-urls=https://0.0.0.0:2379 \
           --listen-peer-urls=https://0.0.0.0:2380 \
           --initial-cluster-token k8s-etcd-cluster \
-          --initial-cluster {{ .Etcd.InitialCluster }} \
-          --initial-cluster-state {{ .Etcd.InitialClusterState }} \
+          --initial-cluster ${ETCD_INITIAL_CLUSTER} \
+          --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE} \
           --experimental-peer-skip-client-san-verification=true \
           --data-dir=/var/lib/etcd \
           --enable-v2 \


### PR DESCRIPTION
This PR changes the etcd3.service systemd unit in order to use environment variables for some of the configuration options.

This makes it easier to use different approaches in the ETCD cluster initialization (that might be required by different cloud providers).

The default value of the environment variable is the same that was previously hardcoded and that should make this PR a drop-in replacement without side effects.