### PR TITLE
Remove init container that installs CNI binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- When calico is used only for Network Policies it will not install the CNI binaries. The CNI in each provider will take care of installing the required binaries.
+
 ### Added
 
 - Add monitoring annotations `prometheus.io/*` and `giantswarm.io/monitoring*` to kube-proxy, k8s-scheduler, k8s-controller-manager and calico.
@@ -14,7 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Changed the path of the ETCD certificate files used in the etcdctl alias.
-- Exposed some of the etcd3.service systemd unit settings via environment variables to make customizations in the configuration easier. 
+- Exposed some of the etcd3.service systemd unit settings via environment variables to make customizations in the configuration easier.
 
 ## [8.0.0] - 2020-08-11
 
@@ -22,15 +26,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Added validation of versions in the cloud config Params struct. Versions outside of supported ranges will cause an
   error to be returned from cloud config-related functions.
-  
+
 ### Changed
 
 - Updated backward incompatible Kubernetes dependencies to v1.18.5.
 
 ### Removed
 
-- Removed `DefaultParams` and `DefaultCloudConfigConfig` functions from the `template` package. Defaults should be 
-  established by the consumer of the library instead. 
+- Removed `DefaultParams` and `DefaultCloudConfigConfig` functions from the `template` package. Defaults should be
+  established by the consumer of the library instead.
 
 ## [7.0.5] - 2020-07-30
 

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -388,6 +388,7 @@ spec:
           securityContext:
             privileged: true
 {{ end -}}
+
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -351,6 +351,7 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
+{{ if not .EnableAWSCNI -}}
       initContainers:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -386,6 +387,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+{{ end -}}
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -351,41 +351,6 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
-      initContainers:
-        # This container installs the CNI binaries
-        # and CNI network config file on each node.
-        - name: install-cni
-          image: {{ .Images.CalicoCNI }}
-          command: ["/install-cni.sh"]
-          env:
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "10-calico.conflist"
-            # Set the hostname based on the k8s node name.
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cni_network_config
-            # Prevents the container from sleeping forever.
-            - name: SLEEP
-              value: "false"
-          resources:
-            requests:
-              cpu: 50m
-              memory: 100Mi
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
-          securityContext:
-            privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -351,7 +351,7 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
-{{ if not .EnableAWSCNI -}}
+      {{ if not .EnableAWSCNI -}}
       initContainers:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -387,8 +387,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
-{{ end -}}
-
+      {{ end -}}
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -351,6 +351,41 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
+      initContainers:
+        # This container installs the CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: {{ .Images.CalicoCNI }}
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          securityContext:
+            privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

The CNI running on a K8S should be in charge of installing it's own CNI binaries (portmap, bridge...)

Currently Calico and AWS CNI where fighting to setup this files:
https://github.com/giantswarm/giantswarm/issues/11077#issuecomment-685457567

And were also causing problems as nodes were being marked as Ready when AWS CNI was not even able to boot:
https://github.com/giantswarm/giantswarm/issues/13086

@whites11 not sure if this file is also being used in Azure, would this change still be fine?