### PR TITLE
Disable cni binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [Unreleased]
 
 - Prevent calico from installing CNI binaries if AWS CNI is enabled
+- Enables metric scraping in calico
 
 ## [7.1.0] - 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Prevent calico from installing CNI binaries if AWS CNI is enabled
+
 ## [7.1.0] - 2020-08-31
 
 ### Changed
 
 - Changed the path of the ETCD certificate files used in the etcdctl alias.
-- Exposed some of the etcd3.service systemd unit settings via environment variables to make customizations in the configuration easier. 
+- Exposed some of the etcd3.service systemd unit settings via environment variables to make customizations in the configuration easier.
 
 ## [7.0.5] - 2020-07-30
 

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -322,12 +322,17 @@ spec:
       labels:
         giantswarm.io/service-type: managed
         k8s-app: calico-node
+        giantswarm.io/monitoring: "true"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9091"
+        giantswarm.io/monitoring-path: "/metrics"
+        giantswarm.io/monitoring-port: "9091"
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -346,6 +351,7 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
+      {{ if not .EnableAWSCNI -}}
       initContainers:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -381,6 +387,7 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+      {{ end -}}
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.


This will be used in aws-operator release 11 and 12