### PR TITLE
Shorten calico-node and aws-node wait timeout and add retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Shorten `calico-node` and `aws-node` wait timeout in `k8s-addons` and add retry for faster cluster initialization.
+
 ## [9.1.2] - 2020-11-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Shorten `calico-node` and `aws-node` wait timeout in `k8s-addons` and add retry for faster cluster initialization.
+- Synchronize `calico-node` pod template labels between `calico-all.yaml` and `calico-policy-only.yaml`.
 
 ## [9.1.2] - 2020-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Shorten `calico-node` and `aws-node` wait timeout in `k8s-addons` and add retry for faster cluster initialization.
+- Shorten `calico-node` wait timeout in `k8s-addons` and add retry for faster cluster initialization.
 - Synchronize `calico-node` pod template labels between `calico-all.yaml` and `calico-policy-only.yaml`.
+- Remove non-functional `aws-node` wait in `k8s-addons`.
 
 ## [9.1.2] - 2020-11-23
 

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -136,7 +136,7 @@ done
 {{ if .EnableAWSCNI -}}
 while
     echo "Waiting for aws-node to be ready..."
-    kubectl -n kube-system -l app.kubernetes.io/name=aws-node wait --for=condition=Ready --timeout=1m pods
+    kubectl -n kube-system -l k8s-app=aws-node wait --for=condition=Ready --timeout=1m pods
     [ "$?" -ne "0" ]
 do
     echo "aws-node was not ready after 1 minute"

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -134,12 +134,22 @@ do
 done
 
 {{ if .EnableAWSCNI -}}
-echo "Waiting for aws-node to be ready..."
-kubectl -n kube-system -l app.kubernetes.io/name=aws-node wait --for=condition=Ready --timeout=10m pods
+while
+    echo "Waiting for aws-node to be ready..."
+    kubectl -n kube-system -l app.kubernetes.io/name=aws-node wait --for=condition=Ready --timeout=1m pods
+    [ "$?" -ne "0" ]
+do
+    echo "aws-node was not ready after 1 minute"
+done
 {{ end -}}
 
-echo "Waiting for calico-node to be ready..."
-kubectl -n kube-system -l app.kubernetes.io/name=calico-node wait --for=condition=Ready --timeout=10m pods
+while
+    echo "Waiting for calico-node to be ready..."
+    kubectl -n kube-system -l app.kubernetes.io/name=calico-node wait --for=condition=Ready --timeout=1m pods
+    [ "$?" -ne "0" ]
+do
+    echo "calico-node was not ready after 1 minute"
+done
 
 # apply default storage class
 if [ -f /srv/default-storage-class.yaml ]; then

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -133,16 +133,6 @@ do
     done
 done
 
-{{ if .EnableAWSCNI -}}
-while
-    echo "Waiting for aws-node to be ready..."
-    kubectl -n kube-system -l k8s-app=aws-node wait --for=condition=Ready --timeout=1m pods
-    [ "$?" -ne "0" ]
-do
-    echo "aws-node was not ready after 1 minute"
-done
-{{ end -}}
-
 while
     echo "Waiting for calico-node to be ready..."
     kubectl -n kube-system -l app.kubernetes.io/name=calico-node wait --for=condition=Ready --timeout=1m pods
@@ -150,6 +140,8 @@ while
 do
     echo "calico-node was not ready after 1 minute"
 done
+
+echo "calico-node is ready"
 
 # apply default storage class
 if [ -f /srv/default-storage-class.yaml ]; then

--- a/files/k8s-resource/calico-policy-only.yaml
+++ b/files/k8s-resource/calico-policy-only.yaml
@@ -307,6 +307,7 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
+    app.kubernetes.io/name: calico-node
     giantswarm.io/service-type: managed
     k8s-app: calico-node
 spec:
@@ -320,6 +321,7 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: calico-node
         giantswarm.io/service-type: managed
         k8s-app: calico-node
         giantswarm.io/monitoring: "true"


### PR DESCRIPTION
I found during testing that `kubectl wait` has surprising behavior when using `wait` with a pod label selector. Rather than timing out after the specified timeout, it waits for the timeout for each matching pod in sequence. When Calico is not immediately ready (common during cluster creation), this causes us to wait for 40 minutes (10 * # of nodes) rather than the expected 10. I am adjusting the existing code to wait for only one minute and wrapped it with a loop so we can continue with cluster initialization more quickly.

## Checklist

- [x] Update changelog in CHANGELOG.md.
