### PR TITLE
Set configurable node labels in k8s-label-node unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Set configurable labels with `k8s-label-node` unit as well to update old labels when node identity doesn't change on upgrade.
+
 ## [9.1.0] - 2020-10-29
 
 ### Added

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -362,9 +362,9 @@ systemd:
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/master=""; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master'; \
-		for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
-			kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
-		done'
+        for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
+            kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
+        done'
       [Install]
       WantedBy=multi-user.target
   - name: k8s-label-node.timer

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -361,9 +361,9 @@ systemd:
       ExecStart=/bin/sh -c '\
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/master=""; \
-        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master'; \
-        for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
-            kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
+        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master; \
+        for l in $(echo "{{.Cluster.Kubernetes.Kubelet.Labels}}" | tr "," " "); do \
+            kubectl label nodes --overwrite $(hostname | tr "[:upper:]" "[:lower:]") $l; \
         done'
       [Install]
       WantedBy=multi-user.target

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -361,7 +361,10 @@ systemd:
       ExecStart=/bin/sh -c '\
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/master=""; \
-        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master'
+        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master'; \
+		for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
+			kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
+		done'
       [Install]
       WantedBy=multi-user.target
   - name: k8s-label-node.timer

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -228,8 +228,8 @@ systemd:
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/worker=""; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=worker; \
-        for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
-            kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
+        for l in $(echo "{{.Cluster.Kubernetes.Kubelet.Labels}}" | tr "," " "); do \
+            kubectl label nodes --overwrite $(hostname | tr "[:upper:]" "[:lower:]") $l; \
         done'
       [Install]
       WantedBy=multi-user.target

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -228,9 +228,9 @@ systemd:
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/worker=""; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=worker; \
-		for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
-			kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
-		done'
+        for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
+            kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
+        done'
       [Install]
       WantedBy=multi-user.target
   - name: k8s-label-node.timer

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -227,7 +227,10 @@ systemd:
       ExecStart=/bin/sh -c '\
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/worker=""; \
-        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=worker'
+        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=worker; \
+		for l in $(echo {{.Cluster.Kubernetes.Kubelet.Labels}} | tr ',' ' '); do \
+			kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') $l; \
+		done'
       [Install]
       WantedBy=multi-user.target
   - name: k8s-label-node.timer


### PR DESCRIPTION
When upgrading a node so that the node identity doesn't change, old
labels need to be overwritten in order to become effective. Therefore
those must be applied in `k8s-label-node` unit.

## Checklist

- [x] Update changelog in CHANGELOG.md.
