### PR TITLE
aws-decrease-hostnetwork-pods-count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- AWS - decrease `hostnetworkpod` count for calculating pod limit due `cert-exporter`  running without host network since `v1.3.0`.
+
 ## [9.1.1] - 2020-11-09
 
 ### Added

--- a/files/conf/setup-kubelet-environment
+++ b/files/conf/setup-kubelet-environment
@@ -18,12 +18,12 @@ if [ $1 == "master" ]; then
   # 1 ENI for the node, 1 for ETCD
   reserved_eni=2
   # Only counting daemonsets, as they are mandatory in all nodes
-  hostnetwork_pods=9
+  hostnetwork_pods=8
 else
   # 1 ENI for the node
   reserved_eni=1
   # Only counting daemonsets, as they are mandatory in all nodes
-  hostnetwork_pods=6
+  hostnetwork_pods=5
 fi
 
 # Formula for max amount of pods in AWS CNI is (enis-$reserved_enis)*(ips_eni-1)+$host_network_pods


### PR DESCRIPTION
towards https://github.com/giantswarm/releases/pull/489/files#diff-0558904bd7b9ba9c4978a85be9be05734a316391b7e871a1a6045c461bcafb7cR74-R79

cert-expoter `v1.3.0` is no longer running on hostnetwork so removing it from the numbers to calculate  pod limit.

This is for AWS Only

## Checklist

- [x] Update changelog in CHANGELOG.md.
