### PR TITLE
update scheduler config version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Drop support for Kubernetes 1.16-1.18.
+
 ### Changed
 
-- Move scheduler config from v1alpha1 to v1beta1.
+- Move scheduler config from `v1alpha1` to `v1beta1`.
+- Rename module from `github.com/giantswarm/k8scloudconfig/v9` to `github.com/giantswarm/k8scloudconfig/v10`.
 
 ## [9.3.0] - 2020-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Move scheduler config from v1alpha1 to v1beta1.
+
 ## [9.3.0] - 2020-12-07
 
 ## [9.2.0] - 2020-12-01

--- a/files/config/scheduler.yaml
+++ b/files/config/scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/kubeconfig/scheduler.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/k8scloudconfig/v9
+module github.com/giantswarm/k8scloudconfig/v10
 
 go 1.14
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -5,7 +5,7 @@ package key
 const (
 	CalicoVersionConstraint                       = ">= 3.10.0 < 3.16.0"
 	EtcdVersionConstraint                         = ">= 3.4.0 < 3.5.0"
-	KubernetesVersionConstraint                   = ">= 1.16.0"
+	KubernetesVersionConstraint                   = ">= 1.19.0"
 	KubernetesApiHealthzVersionConstraint         = ">= 0.1.1"
 	KubernetesNetworkSetupDockerVersionConstraint = ">= 0.2.0"
 )

--- a/pkg/template/cloudconfig.go
+++ b/pkg/template/cloudconfig.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/k8scloudconfig/v9/pkg/ignition"
+	"github.com/giantswarm/k8scloudconfig/v10/pkg/ignition"
 )
 
 const (

--- a/pkg/template/cloudconfig_test.go
+++ b/pkg/template/cloudconfig_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/giantswarm/k8scloudconfig/v9/pkg/ignition"
+	"github.com/giantswarm/k8scloudconfig/v10/pkg/ignition"
 )
 
 func TestCloudConfig(t *testing.T) {

--- a/pkg/template/cloudconfig_test.go
+++ b/pkg/template/cloudconfig_test.go
@@ -74,7 +74,7 @@ func TestCloudConfig(t *testing.T) {
 		}
 		tc.params.Extension = nopExtension{}
 		tc.params.Files = files
-		tc.params.Versions = releaseVersionsAWS1150
+		tc.params.Versions = releaseVersionsValid
 		tc.params.Images = BuildImages("docker.io", tc.params.Versions)
 		tc.params.DockerhubToken = "token"
 

--- a/pkg/template/validation.go
+++ b/pkg/template/validation.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/k8scloudconfig/v9/pkg/key"
+	"github.com/giantswarm/k8scloudconfig/v10/pkg/key"
 )
 
 func validateComponentVersion(name, versionString, constraintString string) error {

--- a/pkg/template/validation_test.go
+++ b/pkg/template/validation_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/Masterminds/semver/v3"
 )
 
-var releaseVersionsAWS1150 = Versions{
-	Calico:                       "3.10.4",
-	CRITools:                     "1.16.1",
-	Etcd:                         "3.4.9",
-	Kubernetes:                   "1.16.13",
+var releaseVersionsValid = Versions{
+	Calico:                       "3.15.3",
+	CRITools:                     "1.19.0",
+	Etcd:                         "3.4.14",
+	Kubernetes:                   "1.19.4",
 	KubernetesAPIHealthz:         "0.1.1",
 	KubernetesNetworkSetupDocker: "0.2.0",
 }
 
-var releaseVersionsAWS900 = Versions{
+var releaseVersionsInvalid = Versions{
 	Calico:                       "3.9.1",
 	CRITools:                     "1.15.0",
 	Etcd:                         "3.3.15",
@@ -66,47 +66,48 @@ func Test_Params_Validation(t *testing.T) {
 	}{
 		{
 			errorMatcher: nilErrorMatcher,
-			name:         "case 0: aws release 11.5.0 versions are valid",
-			versions:     releaseVersionsAWS1150,
+			name:         "case 0: valid release versions are valid",
+			versions:     releaseVersionsValid,
 		},
 		{
 			errorMatcher: invalidVersionMatcher,
 			name:         "case 1: empty kubernetes version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "Kubernetes", ""),
+			versions:     editVersions(releaseVersionsValid, "Kubernetes", ""),
 		},
 		{
 			errorMatcher: validationErrorMatcher,
 			name:         "case 2: old kubernetes version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "Kubernetes", releaseVersionsAWS900.Kubernetes),
+			versions:     editVersions(releaseVersionsValid, "Kubernetes", releaseVersionsInvalid.Kubernetes),
 		},
 		{
 			errorMatcher: validationErrorMatcher,
 			name:         "case 3: old calico version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "Calico", releaseVersionsAWS900.Calico),
+			versions:     editVersions(releaseVersionsValid, "Calico", releaseVersionsInvalid.Calico),
 		},
 		{
 			errorMatcher: validationErrorMatcher,
 			name:         "case 4: old etcd version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "Etcd", releaseVersionsAWS900.Etcd),
+			versions:     editVersions(releaseVersionsValid, "Etcd", releaseVersionsInvalid.Etcd),
 		},
 		{
 			errorMatcher: validationErrorMatcher,
 			name:         "case 5: old critools version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "CRITools", releaseVersionsAWS900.CRITools),
+			versions:     editVersions(releaseVersionsValid, "CRITools", releaseVersionsInvalid.CRITools),
 		},
 		{
 			errorMatcher: validationErrorMatcher,
 			name:         "case 6: old api healthz version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "KubernetesAPIHealthz", releaseVersionsAWS900.KubernetesAPIHealthz),
+			versions:     editVersions(releaseVersionsValid, "KubernetesAPIHealthz", releaseVersionsInvalid.KubernetesAPIHealthz),
 		},
 		{
 			errorMatcher: validationErrorMatcher,
 			name:         "case 7: old network setup version is invalid",
-			versions:     editVersions(releaseVersionsAWS1150, "KubernetesNetworkSetupDocker", releaseVersionsAWS900.KubernetesNetworkSetupDocker),
+			versions:     editVersions(releaseVersionsValid, "KubernetesNetworkSetupDocker", releaseVersionsInvalid.KubernetesNetworkSetupDocker),
 		},
 	}
 
 	for i, tc := range testCases {
+		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log(tc.name)
 			params := Params{


### PR DESCRIPTION
v1alpha1 is no longer supported in Kubernetes 1.19. We will need to determine if this is backwards compatible with <=1.18 before releasing.

Based on https://kubernetes.io/docs/reference/scheduling/config/
Towards https://github.com/giantswarm/roadmap/issues/247#issuecomment-741343638

## Checklist

- [x] Update changelog in CHANGELOG.md.
