### PR TITLE
Set kubelet runtime request timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Move Calico (full and policy-only) CRDs into a separate file (`/srv/calico-crds.yaml`) and upgrade to CRD v1 API.
-- Set streamingConnectionIdleTimeout to 1hr (was previously unset, default is 4h).
+- Set `streamingConnectionIdleTimeout` to 1hr (was previously unset, default is 4h).
+- Set `runtimeRequestDuration` to 2m (previously unset, default is 2m).
 
 ## [10.0.0] - 2020-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Move Calico (full and policy-only) CRDs into a separate file (`/srv/calico-crds.yaml`) and upgrade to CRD v1 API.
 - Set `streamingConnectionIdleTimeout` to 1hr (was previously unset, default is 4h).
-- Set `runtimeRequestDuration` to 2m (previously unset, default is 2m).
+- Set `runtimeRequestTimeout` to 2m (previously unset, default is 2m).
 
 ## [10.0.0] - 2020-12-10
 

--- a/files/config/kubelet-master.yaml.tmpl
+++ b/files/config/kubelet-master.yaml.tmpl
@@ -46,5 +46,6 @@ tlsCipherSuites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
   - TLS_RSA_WITH_AES_256_GCM_SHA384
   - TLS_RSA_WITH_AES_128_GCM_SHA256
+runtimeRequestTimeout: 2m
 serializeImagePulls: false
 streamingConnectionIdleTimeout: 1h

--- a/files/config/kubelet-worker.yaml.tmpl
+++ b/files/config/kubelet-worker.yaml.tmpl
@@ -45,5 +45,6 @@ tlsCipherSuites:
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
   - TLS_RSA_WITH_AES_256_GCM_SHA384
   - TLS_RSA_WITH_AES_128_GCM_SHA256
+runtimeRequestTimeout: 2m
 serializeImagePulls: false
 streamingConnectionIdleTimeout: 1h


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3398

Explicitly sets the kubelet request timeout to 2 minutes (this is the default)

## Checklist

- [x] Update changelog in CHANGELOG.md.
