### PR TITLE
Set api-server request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Move Calico (full and policy-only) CRDs into a separate file (`/srv/calico-crds.yaml`) and upgrade to CRD v1 API.
-- Set streamingConnectionIdleTimeout to 1hr (was previously unset, default is 4h).
+- Set `streamingConnectionIdleTimeout` to 1hr (was previously unset, default is 4h).
+- Set `api-server` request timeout to 1 minute (previously unset, default is 1 minute).
 
 ## [10.0.0] - 2020-12-10
 

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -62,6 +62,7 @@ spec:
     - --audit-log-maxsize=100
     - --audit-policy-file=/etc/kubernetes/policies/audit-policy.yaml
     - --encryption-provider-config=/etc/kubernetes/encryption/k8s-encryption-config.yaml
+    - --request-timeout=1m
     - --requestheader-client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
     - --requestheader-allowed-names=aggregator,{{.Cluster.Kubernetes.API.Domain}},{{.Cluster.Kubernetes.Kubelet.Domain}}
     - --requestheader-extra-headers-prefix=X-Remote-Extra-


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3398

Explicitly set the API server request timeout to 1 minute. This is the default value.

## Checklist

- [x] Update changelog in CHANGELOG.md.
