### PR TITLE
Add deny all netpol to "default", "kube-public" and "kube-node-lease" namespaces

### DIFF
--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -171,7 +171,7 @@ done
 
 # apply network policies:
 NETWORK_POLICIES_FILE="network_policies.yaml"
-NAMESPACES="kube-system giantswarm"
+NAMESPACES="kube-system giantswarm default kube-public kube-node-lease"
 for namespace in ${NAMESPACES}; do
     while
       kubectl apply -f /srv/$NETWORK_POLICIES_FILE -n $namespace


### PR DESCRIPTION
Customer has been running this for a while and they asked to add it by default.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
