### PR TITLE
Fix Calico CRDs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.8.4
+  architect: giantswarm/architect@0.10.0
 
 workflows:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Set `streamingConnectionIdleTimeout` to 1hr (was previously unset, default is 4h).
 - Set `api-server` request timeout to 1 minute (previously unset, default is 1 minute).
 
+### Removed
+
+- Drop bgppeer KeepOriginalNextHop default field.
+
 ## [10.0.0] - 2020-12-10
 
 ### Removed

--- a/files/k8s-resource/calico-crds.yaml
+++ b/files/k8s-resource/calico-crds.yaml
@@ -168,7 +168,6 @@ spec:
                   format: int32
                   type: integer
                 keepOriginalNextHop:
-                  default: false
                   description: Option to keep the original nexthop field when routes
                     are sent to a BGP Peer. Setting "true" configures the selected BGP
                     Peers node to use the "next hop keep;" instead of "next hop self;"(default)


### PR DESCRIPTION
When upgrading to k8s 1.19 I noticed that k8s-addons constantly retries to apply Calico CRD's.
This needs to be fixed by dropping the bgppeer KeepOriginalNextHop default field.
It has been already fixed in upstream: https://github.com/projectcalico/libcalico-go/pull/1353

https://github.com/giantswarm/giantswarm/issues/15878

## Checklist

- [x] Update changelog in CHANGELOG.md.