### PR TITLE
Set service-account-jwks-uri value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## Added
+
+- Set `service-account-jwks-uri` api server value to align with `service-account-issuer` value
+
 ## [10.8.1] - 2021-07-01
 
 ## Added

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -66,6 +66,7 @@ spec:
     - --requestheader-group-headers=X-Remote-Group
     - --requestheader-username-headers=X-Remote-User
     - --service-account-issuer=https://{{.Cluster.Kubernetes.API.Domain}}
+    - --service-account-jwks-uri=https://{{.Cluster.Kubernetes.API.Domain}}/openid/v1/jwks
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --proxy-client-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

This fixes sonobuoys conformance test failure:
```
Failed tests:
[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer [Conformance]
```

related to: https://github.com/giantswarm/giantswarm/issues/18215

---

Please see the following link for some more info.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery