### PR TITLE
only add k8s controller flag if set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add check to only include `EnableCSIMigrationAWSComplete` flag if set to true.
+
 ## [10.9.0] - 2021-08-16
 
 ## Added

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -33,7 +33,7 @@ spec:
     - --use-service-account-credentials=true
     - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
     {{ if .InTreePluginAWSUnregister }}
-    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister={{ .InTreePluginAWSUnregister }}
+    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister=true
     {{ else }}
     - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }}
     {{ end }}

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -32,7 +32,11 @@ spec:
     - --terminated-pod-gc-threshold=10
     - --use-service-account-credentials=true
     - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
+    {{ if .InTreePluginAWSUnregister }}
     - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister={{ .InTreePluginAWSUnregister }}
+    {{ else }}
+    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }}
+    {{ end }}
     - --profiling=false
     - --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
     - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-key.pem

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -32,11 +32,11 @@ spec:
     - --terminated-pod-gc-threshold=10
     - --use-service-account-credentials=true
     - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
-    {{ if .InTreePluginAWSUnregister }}
+    {{- if .InTreePluginAWSUnregister }}
     - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister=true
-    {{ else }}
+    {{- else }}
     - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }}
-    {{ end }}
+    {{- end }}
     - --profiling=false
     - --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem
     - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-key.pem


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

---
InTreePluginAWSUnregister was only introduced in k8s 1.21. This change is to allow k8scloudconfig to still work on older versions by only setting the flag if set true, 