### PR TITLE
Calico service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add access to networkpolicies to calico-kube-controllers service account.
+
+
 ## [10.11.0] - 2021-09-01
 
 ### Changed

--- a/files/k8s-resource/calico-all.yaml
+++ b/files/k8s-resource/calico-all.yaml
@@ -485,6 +485,13 @@ rules:
       - list
   - apiGroups: ["crd.projectcalico.org"]
     resources:
+      - networkpolicies
+    verbs:
+      - create
+      - get
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
       - blockaffinities
       - ipamblocks
       - ipamhandles


### PR DESCRIPTION
Fixing the following error in `calico-kube-controllers`:
```
E0803 03:06:45.223634       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.0-rc.0/tools/cache/reflector.go:167: Failed to watch *v1.NetworkPolicy: failed to list *v1.NetworkPolicy: networkpolicies.networking.k8s.io is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot list resource "networkpolicies" in API group "networking.k8s.io" at the cluster scope
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
