### PR TITLE
Remove `rpc-statd.service` dependency on `kubelet.service` on `AWS` and `Azure`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `rpc-statd.service` dependency on `kubelet.service` on `AWS` and `Azure`. 
+
 ## [11.0.1] - 2022-02-01
 
 ### Changed

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -297,8 +297,8 @@ systemd:
     enabled: true
     contents: |
       [Unit]
-      Wants=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service rpc-statd.service
-      After=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service rpc-statd.service
+      Wants=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service{{ if eq .Cluster.Kubernetes.CloudProvider "" }} rpc-statd.service{{ end }}
+      After=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service{{ if eq .Cluster.Kubernetes.CloudProvider "" }} rpc-statd.service{{ end }}
       Description=k8s-kubelet
       StartLimitIntervalSec=0
       [Service]

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -214,8 +214,8 @@ systemd:
     enabled: true
     contents: |
       [Unit]
-      Wants=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service rpc-statd.service
-      After=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service rpc-statd.service
+      Wants=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service{{ if eq .Cluster.Kubernetes.CloudProvider "" }} rpc-statd.service{{ end }}
+      After=k8s-setup-network-env.service k8s-setup-kubelet-config.service k8s-extract.service{{ if eq .Cluster.Kubernetes.CloudProvider "" }} rpc-statd.service{{ end }}
       Description=k8s-kubelet
       StartLimitIntervalSec=0
       [Service]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20805

RPCbind (triggered by rpc-statd) is needed for NFS v3.
Azure and AWS do not use it (they use v4) and there is an open port that some customers don't like.
This PR disables rpc-statd for non-kvm clusters.

## Checklist

- [x] Update changelog in CHANGELOG.md.
