### PR TITLE
Fix `calico-kube-controllers` permissions for `networkpolicies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `calico-kube-controllers` permissions for `networkpolicies`.
+
 ## [10.16.0] - 2022-01-17
 
 ### Added

--- a/files/k8s-resource/calico-all.yaml
+++ b/files/k8s-resource/calico-all.yaml
@@ -499,6 +499,8 @@ rules:
       - create
       - get
       - list
+      - update
+      - delete
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20918

Cherry-picked from #999 to `release-v10.16.x`