### PR TITLE
increase-db-max-size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Increase max storage size for etcd to 8GB.
+
 ## [12.0.0] - 2022-03-15
 
 ### Changed

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -228,7 +228,7 @@ systemd:
           --experimental-peer-skip-client-san-verification=true \
           --data-dir=/var/lib/etcd \
           --enable-v2 \
-	  --quota-backend-bytes 8589934592 \
+          --quota-backend-bytes 8589934592 \
           --logger=zap
       [Install]
       WantedBy=multi-user.target

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -228,6 +228,7 @@ systemd:
           --experimental-peer-skip-client-san-verification=true \
           --data-dir=/var/lib/etcd \
           --enable-v2 \
+	  --quota-backend-bytes 8589934592 \
           --logger=zap
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
It does not have a negative impact,  the problem is that once the DB gets over the default 2GB the DB is locked and you cannot do anything until you increase the DB size or delete data and then disarm the alarm