### PR TITLE
Kube proxy vpa service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added systemd unit to create VPA for kube-proxy.
+
 ## [13.3.0] - 2022-04-01
 
 ### Removed

--- a/files/conf/kube-proxy-vpa
+++ b/files/conf/kube-proxy-vpa
@@ -1,0 +1,22 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-proxy
+    giantswarm.io/service-type: system
+    k8s-app: kube-proxy
+    kubernetes.io/cluster-service: "true"
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: kube-proxy
+      controlledValues: RequestsOnly
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: kube-proxy
+  updatePolicy:
+    updateMode: Auto

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -738,7 +738,7 @@ storage:
       filesystem: root
       mode: 0444
       contents:
-      source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/kube-proxy-vpa" }}"
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/kube-proxy-vpa" }}"
 
     {{ range .Extension.Files -}}
     - path: {{ .Metadata.Path }}

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -407,6 +407,7 @@ systemd:
       After=k8s-addons.service
       [Service]
       Type=oneshot
+      Restart=on-failure
       ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/kubeconfig/addons.yaml ]; do echo 'Waiting for /etc/kubernetes/kubeconfig/addons.yaml to be written' && sleep 10; done"
       ExecStartPre=/bin/bash -c "while ! /opt/bin/kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml get crd verticalpodautoscalers.autoscaling.k8s.io; do echo 'Waiting for VPA CRD to exists' && sleep 10; done"
       ExecStart=/opt/bin/kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml apply -f /srv/kube-proxy-vpa.yaml

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -408,7 +408,6 @@ systemd:
       [Service]
       Type=oneshot
       Restart=on-failure
-      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/kubeconfig/addons.yaml ]; do echo 'Waiting for /etc/kubernetes/kubeconfig/addons.yaml to be written' && sleep 10; done"
       ExecStartPre=/bin/bash -c "while ! /opt/bin/kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml get crd verticalpodautoscalers.autoscaling.k8s.io; do echo 'Waiting for VPA CRD to exists' && sleep 10; done"
       ExecStart=/opt/bin/kubectl --kubeconfig=/etc/kubernetes/kubeconfig/addons.yaml apply -f /srv/kube-proxy-vpa.yaml
       [Install]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21494

This PR adds a new systemd unit to master nodes that runs after `k8s-addons` and waits until `verticalpodautoscaler` CR exists before it creates the VPA for kube-proxy.
Hacky solution maybe, but I tested it and it works just fine.

## Checklist

- [x] Update changelog in CHANGELOG.md.
