### PR TITLE
Add extra sa key args for irsa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add extra IRSA key args.
+
 ## [13.4.0] - 2022-04-04
 
 ### Added

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -71,6 +71,9 @@ spec:
     - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --proxy-client-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
     - --proxy-client-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    {{ range .IrsaSAKeyArgs -}}
+    - {{ . }}
+    {{ end -}}
     resources:
       requests:
         cpu: 300m

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -49,6 +49,8 @@ type Params struct {
 	ImagePullProgressDeadline string
 	// Container images used in the cloud-config templates
 	Images Images
+	// IAM Roles for Service Account key files.
+	IrsaSAKeyArgs []string
 	// Kubernetes components allow the passing of extra `docker run` and
 	// `command` arguments to image commands. This allows, for example,
 	// the addition of cloud provider extensions.


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/21736

TL;DR 

Key files for new IRSA service account which signs JWT need to be after older service account key files.

## Checklist

- [x] Update changelog in CHANGELOG.md.