### PR TITLE
Hostname wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed syntax error in kube-apiserver manifest introduced in 13.7.0.
+
+### Added
+
+- Improve k8s-kubelet unit definition to prevent nodes from joining as 'localhost'.
+
 ## [13.7.0] - 2022-05-31
 
 ### Changed

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -42,11 +42,11 @@ spec:
     - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
     - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
     - --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}}
-    {{- if .Etcd.HighAvailability -}}
+    {{ if .Etcd.HighAvailability -}}
     - --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:2379
-    {{- else -}}
+    {{ else -}}
     - --etcd-servers=https://127.0.0.1:2379
-    {{- end -}}
+    {{ end -}}
     - --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem
     - --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem
     - --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -316,6 +316,7 @@ systemd:
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
       Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin"
+      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" == "localhost" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}
         {{ . }} \

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -216,6 +216,7 @@ systemd:
       Environment="ETCD_CERT_FILE=/etc/kubernetes/ssl/calico/etcd-cert"
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
+      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" == "localhost" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}
         {{ . }} \


### PR DESCRIPTION
- Fixed a typo in api server manifest
- wait for hostname to not be "localhost" before starting the kubelet

## Checklist

- [x] Update changelog in CHANGELOG.md.
