### PR TITLE
Override default auditd configuration to capture `execve` syscalls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Override default auditd configuration to capture `execve` syscalls.
+
 ## [13.8.0] - 2022-06-07
 
 ### Fixed

--- a/files/conf/99-default.rules
+++ b/files/conf/99-default.rules
@@ -1,0 +1,3 @@
+# Overridden by Giant Swarm.
+-a exit,always -F arch=b64 -S execve -k auditing
+-a exit,always -F arch=b32 -S execve -k auditing

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -741,6 +741,17 @@ storage:
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/kube-proxy-vpa" }}"
 
+    - path : /etc/audit/rules.d/99-default.rules
+      overwrite: true
+      filesystem: root
+      mode: 420
+      user:
+        id: 0
+      group:
+        id: 0
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{ index .Files "conf/99-default.rules" }}"
+
     {{ range .Extension.Files -}}
     - path: {{ .Metadata.Path }}
       filesystem: root

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -412,6 +412,17 @@ storage:
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/k8s-extract" }}"
 
+    - path : /etc/audit/rules.d/99-default.rules
+      overwrite: true
+      filesystem: root
+      mode: 420
+      user:
+        id: 0
+      group:
+        id: 0
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{ index .Files "conf/99-default.rules" }}"
+
     {{ range .Extension.Files -}}
     - path: {{ .Metadata.Path }}
       filesystem: root


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22498

## Checklist

- [x] Update changelog in CHANGELOG.md.
