### PR TITLE
Override default auditd configuration to capture `execve` syscalls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix syntax error in k8s-addons.
+
 ## [13.9.0] - 2022-07-04
 
 ### Added

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -93,23 +93,23 @@ kubectl apply -f /srv/calico-crd-installer-rbac.yaml
 kubectl apply -f /srv/calico-crd-installer.yaml
 kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-crd-installer
 
-{{- if not .CalicoPolicyOnly }}
+{{ if not .CalicoPolicyOnly }}
 # TODO: remove migrator once all clusters have been migrated to kubernetes datastore
 kubectl apply -f /srv/calico-datastore-migrator-pre.yaml
 kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-datastore-migrator-pre
-{{ end -}}
+{{ end }}
 
-{{ if .CalicoPolicyOnly -}}
+{{ if .CalicoPolicyOnly }}
 ## Apply Calico with network policy features only
 CNI_FILE="calico-policy-only.yaml"
-{{ if .EnableAWSCNI -}}
+{{ if .EnableAWSCNI }}
 ## Apply AWS VPC CNI
 CNI_FILE="${CNI_FILE} aws-cni.yaml"
-{{ end -}}
-{{ else -}}
+{{ end }}
+{{ else }}
 ## Apply Calico with all its components
 CNI_FILE="calico-all.yaml"
-{{ end -}}
+{{ end }}
 
 for manifest in ${CNI_FILE}
 do


### PR DESCRIPTION
Depending on the flags set while generating the template, the `k8s-addons` file might be invalid (two lines put on the same line).

This PR fixes that.

## Checklist

- [x] Update changelog in CHANGELOG.md.
