### PR TITLE
fix containerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Copy `crictl.yaml` on master and worker nodes.
+
 ## [14.0.0] - 2022-07-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Copy `crictl.yaml` on master and worker nodes.
+- Copy `crictl.yaml` on worker nodes.
 
 ## [14.0.0] - 2022-07-14
 

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -753,7 +753,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl" }}"
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl.yaml" }}"
 
     - path: /etc/profile.d/setup-etcdctl.sh
       filesystem: root

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -753,7 +753,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl.yaml" }}"
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl" }}"
 
     - path: /etc/profile.d/setup-etcdctl.sh
       filesystem: root

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -421,6 +421,12 @@ storage:
         id: 0
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{ index .Files "conf/containerd-config.toml" }}"
+
+    - path: /etc/crictl.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl.yaml" }}"
  
     - path : /etc/systemd/system/containerd.service.d/10-use-custom-config.conf
       filesystem: root

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -426,7 +426,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl.yaml" }}"
+        source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/crictl" }}"
  
     - path : /etc/systemd/system/containerd.service.d/10-use-custom-config.conf
       filesystem: root


### PR DESCRIPTION
The file `crictl.yaml` was not placed on the worker node correctly.

## Checklist

- [x] Update changelog in CHANGELOG.md.