### PR TITLE
Revert applying aws-cloud-controller-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Revert applying `aws-cloud-controller-manager`.
+
 ## [14.0.1] - 2022-07-15
 
 ### Fixed

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -85,11 +85,6 @@ do
 done
 echo "kube-proxy successfully installed"
 
-{{ if eq .Cluster.Kubernetes.CloudProvider "aws" }}
-# install aws-cloud-controller-manager.yaml
-kubectl apply -f /srv/aws-cloud-controller-manager.yaml
-{{ end }}
-
 # restart ds to apply config from configmap
 kubectl delete pods -l app.kubernetes.io/name=kube-proxy -n kube-system
 


### PR DESCRIPTION
Remove applying the aws-ccm as a static pod and go for a usual app deployment.

## Checklist

- [x] Update changelog in CHANGELOG.md.