### PR TITLE
Allow not installing kube-proxy and calico

### DIFF
--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -134,11 +134,11 @@ done
 
 echo "calico-node is ready"
 
-{{- if not .CalicoPolicyOnly }}
+{{ if not .CalicoPolicyOnly }}
 # TODO: remove migrator once all clusters have been migrated to kubernetes datastore
 kubectl apply -f /srv/calico-datastore-migrator-post.yaml
 kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-datastore-migrator-post
-{{ end -}}
+{{ end }}
 
 kubectl delete -f /srv/calico-crd-installer-rbac.yaml
 {{ end }}

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -62,6 +62,7 @@ do
     sleep 3s
 done
 
+{{ if not .DisableKubeProxy }}
 # create kube-proxy configmap
 while
     kubectl create configmap kube-proxy --from-file=kube-proxy.yaml=/srv/kube-proxy-config.yaml -o yaml --dry-run=client | kubectl apply -n kube-system -f -
@@ -99,6 +100,7 @@ kubectl apply -f /srv/calico-datastore-migrator-pre.yaml
 kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-datastore-migrator-pre
 {{ end }}
 
+{{ if not .DisableCalico }}
 {{ if .CalicoPolicyOnly }}
 ## Apply Calico with network policy features only
 CNI_FILE="calico-policy-only.yaml"
@@ -139,6 +141,7 @@ kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kube
 {{ end -}}
 
 kubectl delete -f /srv/calico-crd-installer-rbac.yaml
+{{ end }}
 
 # apply default storage class
 if [ -f /srv/default-storage-class.yaml ]; then

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -89,6 +89,7 @@ echo "kube-proxy successfully installed"
 # restart ds to apply config from configmap
 kubectl delete pods -l app.kubernetes.io/name=kube-proxy -n kube-system
 
+{{ if not .DisableCalico }}
 kubectl apply -f /srv/calico-crd-installer-rbac.yaml
 
 kubectl apply -f /srv/calico-crd-installer.yaml
@@ -100,7 +101,6 @@ kubectl apply -f /srv/calico-datastore-migrator-pre.yaml
 kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-datastore-migrator-pre
 {{ end }}
 
-{{ if not .DisableCalico }}
 {{ if .CalicoPolicyOnly }}
 ## Apply Calico with network policy features only
 CNI_FILE="calico-policy-only.yaml"

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -88,6 +88,7 @@ echo "kube-proxy successfully installed"
 
 # restart ds to apply config from configmap
 kubectl delete pods -l app.kubernetes.io/name=kube-proxy -n kube-system
+{{ end }}
 
 {{ if not .DisableCalico }}
 kubectl apply -f /srv/calico-crd-installer-rbac.yaml

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -24,6 +24,8 @@ type Params struct {
 	InTreePluginAWSUnregister bool
 	// CalicoPolicyOnly flag. When set to true will deploy calico for network policies only.
 	CalicoPolicyOnly bool
+	// DisableCalico allow preventing calico installation.
+	DisableCalico bool
 	// DisableEncryptionAtREST flag. When set removes all manifests from the cloud
 	// config related to Kubernetes encryption at REST.
 	DisableEncryptionAtREST bool
@@ -33,9 +35,11 @@ type Params struct {
 	DisableIngressControllerService bool
 	// DockerhubToken is an auth token used by kubelet to
 	// authenticate/authorize against https://index.docker.io/v1/.
-	DockerhubToken string
-	Etcd           Etcd
-	Extension      Extension
+	// DisableKubeProxy allows to avoid installing kube-proxy in a cluster.
+	DisableKubeProxy bool
+	DockerhubToken   string
+	Etcd             Etcd
+	Extension        Extension
 	// ExtraManifests allows to specify extra Kubernetes manifests in
 	// /opt/k8s-addons script. The manifests are applied after calico is
 	// ready.

--- a/pkg/template/validation.go
+++ b/pkg/template/validation.go
@@ -38,13 +38,15 @@ func (p *Params) Validate() error {
 		return microerror.Mask(err)
 	}
 
-	calicoVersionConstraint := key.CalicoVersionConstraint
-	if p.CalicoPolicyOnly {
-		calicoVersionConstraint = key.CalicoPolicyOnlyVersionConstraint
-	}
+	if !p.DisableCalico {
+		calicoVersionConstraint := key.CalicoVersionConstraint
+		if p.CalicoPolicyOnly {
+			calicoVersionConstraint = key.CalicoPolicyOnlyVersionConstraint
+		}
 
-	if err := validateComponentVersion("Calico", p.Versions.Calico, calicoVersionConstraint); err != nil {
-		return microerror.Mask(err)
+		if err := validateComponentVersion("Calico", p.Versions.Calico, calicoVersionConstraint); err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	if err := validateComponentVersion("Etcd", p.Versions.Etcd, key.EtcdVersionConstraint); err != nil {


### PR DESCRIPTION
Added two flags to avoid installing calico and kube-proxy in a cluster.
This is needed to install CNIs as managed apps.
## Checklist

- [x] Update changelog in CHANGELOG.md.
