### PR TITLE
Change preferred address type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Set `api-server`'s `--kubelet-preferred-address-types` to `Hostname,InternalIP` to fix prometheus scraping of host network pods.
+- Set `api-server`'s `--kubelet-preferred-address-types` to `Hostname` for AWS to fix prometheus scraping of host network pods.
 
 ## [14.1.0] - 2022-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Set `api-server`'s `--kubelet-preferred-address-types` to `Hostname,InternalIP` to fix prometheus scraping of host network pods.
+
 ## [14.1.0] - 2022-07-25
 
 ### Changed

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -31,7 +31,7 @@ spec:
     {{ end -}}
     - --allow-privileged=true
     - --anonymous-auth=true
-    - --kubelet-preferred-address-types=Hostname,InternalIP
+    - --kubelet-preferred-address-types={{ if eq .Cluster.Kubernetes.CloudProvider "aws" }}Hostname{{ else }}InternalIP{{ end }}
     - --secure-port={{.Cluster.Kubernetes.API.SecurePort}}
     - --bind-address=0.0.0.0
     - --etcd-prefix={{.Cluster.Etcd.Prefix}}

--- a/files/manifests/k8s-api-server.yaml
+++ b/files/manifests/k8s-api-server.yaml
@@ -31,7 +31,7 @@ spec:
     {{ end -}}
     - --allow-privileged=true
     - --anonymous-auth=true
-    - --kubelet-preferred-address-types=InternalIP
+    - --kubelet-preferred-address-types=Hostname,InternalIP
     - --secure-port={{.Cluster.Kubernetes.API.SecurePort}}
     - --bind-address=0.0.0.0
     - --etcd-prefix={{.Cluster.Etcd.Prefix}}


### PR DESCRIPTION
On AWS, master nodes have 2 ENIs (network interfaces), one used just for etcd, one used for the rest.
The kubelet binds to the first ethernet card, and does not listen to the other.
When prometheus tries to scrape stuff going through the API server's proxy, it selects the first private IP address as listed in the `Node` resource's status.
There is no guarantee over the order of IP addresses in the node status, and thus scraping can fail or succeed due to randomness.

This PR changes the way the kubelet exposes itself through the proxy, making it prefer the hostname over the private IP address  and hopefully fixing scraping troubles.

## Checklist

- [x] Update changelog in CHANGELOG.md.
