### PR TITLE
Avoid setting `clusterCIDR` in kube proxy's config if calico is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid setting `clusterCIDR` in kube proxy's config if calico is disabled.
+
 ## [14.1.1] - 2022-07-27
 
 ### Changed

--- a/files/config/kube-proxy.yaml
+++ b/files/config/kube-proxy.yaml
@@ -3,7 +3,7 @@ clientConnection:
   kubeconfig: /etc/kubernetes/config/proxy-kubeconfig.yaml
 kind: KubeProxyConfiguration
 mode: iptables
-{{- if not .CalicoPolicyOnly }}
+{{- if and (not .DisableCalico) (not .CalicoPolicyOnly) }}
 clusterCIDR: {{ .Cluster.Calico.Subnet }}/{{ .Cluster.Calico.CIDR }}
 {{- end }}
 {{- if .Cluster.Kubernetes.NetworkSetup.KubeProxy.ConntrackMaxPerCore }}


### PR DESCRIPTION
If there is no calico there should be no `clusterCIDR` field set in kube-proxy's config.
This PR fixes that.

## Checklist

- [x] Update changelog in CHANGELOG.md.
