### PR TITLE
Optional calico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Use docker image instead of binary for `envsubst`.
 
+### Fixed
+
+- Don't fail while parsing release component versions if calico is not present in the Release.
+
 ## [14.1.2] - 2022-08-02
 
 ### Fixed

--- a/pkg/template/release.go
+++ b/pkg/template/release.go
@@ -59,9 +59,10 @@ func ExtractComponentVersions(releaseComponents []v1alpha1.ReleaseSpecComponent)
 	{
 		component, err := findComponent(releaseComponents, "calico")
 		if err != nil {
-			return Versions{}, err
+			// This is ok, as Calico is not mandatory any more.
+		} else {
+			versions.Calico = fmt.Sprintf("v%s", component.Version)
 		}
-		versions.Calico = fmt.Sprintf("v%s", component.Version)
 	}
 
 	return versions, nil


### PR DESCRIPTION
Since calico is now opt-out, we don't want to fail while parsing release component versions if calico is not present in the Release CR.

This PR does just that

## Checklist

- [x] Update changelog in CHANGELOG.md.
