### PR TITLE
Authn/Authz for scheduler and ccm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enable authn/authz for scheduler/ccm to allow prometheus scraping metrics.
+
 ## [14.3.0] - 2022-08-25
 
 ### Changed

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -36,6 +36,8 @@ spec:
     - --terminated-pod-gc-threshold=10
     - --use-service-account-credentials=true
     - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
+    - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
+    - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
     {{- if .InTreePluginAWSUnregister }}
     - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister=true
     {{- else }}

--- a/files/manifests/k8s-scheduler.yaml
+++ b/files/manifests/k8s-scheduler.yaml
@@ -26,6 +26,8 @@ spec:
     - --address=127.0.0.1
     - --feature-gates=TTLAfterFinished=true
     - --config=/etc/kubernetes/config/scheduler.yaml
+    - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/scheduler.yaml
+    - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/scheduler.yaml
     - --profiling=false
     - --v=2
     resources:


### PR DESCRIPTION
For v18:

Issues: 
https://github.com/giantswarm/giantswarm/issues/23421
https://github.com/giantswarm/roadmap/issues/1345

External aws-ccm and azure-ccm will be handled in a separate PR.

## Checklist

- [x] Update changelog in CHANGELOG.md.