### PR TITLE
Hostname check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Check hostname is up to date on azure before starting the kubelet.
+
 ## [14.4.0] - 2022-08-29
 
 ### Changed

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -312,8 +312,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin"
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
-      ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
-      ExecStartPre=/bin/bash -c 'while HN="$(hostname)" && [ "$HN" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is unexpected (want $(cat /etc/desired-host-name), got $HN)" ;done;'
+      ExecStartPre=ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -313,7 +313,7 @@ systemd:
       Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin"
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
       ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
-      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
+      ExecStartPre=/bin/bash -c 'while HN="$(hostname)" && [ "$HN" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is unexpected (want $(cat /etc/desired-host-name), got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -311,7 +311,10 @@ systemd:
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
       Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin"
-      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" == "localhost" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
+      {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
+      ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
+      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
+      {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}
         {{ . }} \

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -312,7 +312,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin"
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
-      ExecStartPre=ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
+      ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -212,8 +212,7 @@ systemd:
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
-      ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
-      ExecStartPre=/bin/bash -c 'while HN="$(hostname)" && [ "$HN" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is unexpected (want $(cat /etc/desired-host-name), got $HN)" ;done;'
+            ExecStartPre=ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -212,7 +212,7 @@ systemd:
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
-      ExecStartPre=ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
+      ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -213,7 +213,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
       ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
-      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is unexpected (want $(cat /etc/desired-host-name), got $(hostname))" ;done;'
+      ExecStartPre=/bin/bash -c 'while HN="$(hostname)" && [ "$HN" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is unexpected (want $(cat /etc/desired-host-name), got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -213,7 +213,7 @@ systemd:
       EnvironmentFile=/etc/network-environment
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
       ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
-      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
+      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is unexpected (want $(cat /etc/desired-host-name), got $(hostname))" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -211,7 +211,10 @@ systemd:
       Environment="ETCD_CERT_FILE=/etc/kubernetes/ssl/calico/etcd-cert"
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
-      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" == "localhost" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
+      {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
+      ExecStartPre=/bin/bash -c 'curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name'
+      ExecStartPre=/bin/bash -c 'while [ "$(hostname)" != "$(cat /etc/desired-host-name)" ] ;  do sleep 2s ; echo "hostname is still localhost, waiting" ;done;'
+      {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}
         {{ . }} \

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -212,7 +212,7 @@ systemd:
       Environment="ETCD_KEY_FILE=/etc/kubernetes/ssl/calico/etcd-key"
       EnvironmentFile=/etc/network-environment
       {{- if eq .Cluster.Kubernetes.CloudProvider "azure" }}
-            ExecStartPre=ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
+      ExecStartPre=ExecStartPre=/bin/bash -c 'while (curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r .compute.osProfile.computerName >/etc/desired-host-name) && DES="$(cat /etc/desired-host-name)" && [ "$DES" != "" ] && HN="$(hostname)" && [ "$HN" != "$DES" ] ;  do sleep 2s ; echo "hostname is unexpected (want $DES, got $HN)" ;done;'
       {{- end }}
       ExecStart=/opt/bin/kubelet \
         {{ range .Kubernetes.Kubelet.CommandExtraArgs -}}


### PR DESCRIPTION
Sometimes, azure VMs take some time to have their hostname properly set.
This PR adds a sanity check that ensures the hostname is correct before starting the kubelet.
Without the check, node can't bootstrap correctly

## Checklist

- [x] Update changelog in CHANGELOG.md.
