### PR TITLE
K8s 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Remove dockershim parameters from kubelet systemd unit.
+
 ## [14.5.1] - 2022-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Remove dockershim parameters from kubelet systemd unit.
 - Remove --address flag from scheduler's manifest.
+- Remove unused ImagePullProgressDeadline setting.
 
 ## [14.5.1] - 2022-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Remove dockershim parameters from kubelet systemd unit.
+- Remove --address flag from scheduler's manifest.
 
 ## [14.5.1] - 2022-08-31
 

--- a/files/manifests/k8s-scheduler.yaml
+++ b/files/manifests/k8s-scheduler.yaml
@@ -23,7 +23,6 @@ spec:
     image: {{ .Images.KubeScheduler }}
     command:
     - kube-scheduler
-    - --address=127.0.0.1
     - --feature-gates=TTLAfterFinished=true
     - --config=/etc/kubernetes/config/scheduler.yaml
     - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/scheduler.yaml

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -329,8 +329,6 @@ systemd:
         --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
         {{ end -}}
         --pod-infra-container-image={{ .Images.Pause }} \
-        --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
-        --network-plugin=cni \
         --register-node=true \
         --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
         --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -52,9 +52,6 @@ type Params struct {
 	// then apply the manifest by adding it to ExtraManifests.
 	ExtraManifests []string
 	Files          Files
-	// ImagePullProgressDeadline is the duration after which image pulling is
-	// cancelled if no progress has been made.
-	ImagePullProgressDeadline string
 	// Container images used in the cloud-config templates
 	Images Images
 	// IAM Roles for Service Account key files.

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -229,8 +229,6 @@ systemd:
         --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
         {{ end -}}
         --pod-infra-container-image={{ .Images.Pause }} \
-        --image-pull-progress-deadline={{.ImagePullProgressDeadline}} \
-        --network-plugin=cni \
         --register-node=true \
         --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
         --node-labels="node.kubernetes.io/worker,role=worker,ip=${DEFAULT_IPV4},{{.Cluster.Kubernetes.Kubelet.Labels}}" \


### PR DESCRIPTION
Changes needed to support k8s 1.24.
They are deprecated flags that are unused in 1.23 anyway

## Checklist

- [x] Update changelog in CHANGELOG.md.
