### PR TITLE
calico-crd-installer: Tolerate `node.cloudprovider.kubernetes.io/uninitialized`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- calico-crd-installer: Tolerate `node.cloudprovider.kubernetes.io/uninitialized`.
+
 ## [15.0.0] - 2022-09-07
 
 ### Added

--- a/files/k8s-resource/calico-crd-installer.yaml
+++ b/files/k8s-resource/calico-crd-installer.yaml
@@ -21,6 +21,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
       restartPolicy: Never
       serviceAccountName: calico-init
   backoffLimit: 4


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.
