### PR TITLE
Irsa remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Remove --address flag from scheduler's manifest.
 - Remove unused ImagePullProgressDeadline setting.
 
+## [14.6.0] - 2022-10-24
+
+### Changed
+
+- Allow specifying `--service-account-signing-key-file` and `--service-account-key-file` API Server flags.
+
+### Removed
+
+- IRSA-specific Params.
+
 ## [14.5.2] - 2022-10-11
 
 ### Changed
@@ -1234,7 +1244,8 @@ chart-operator).
 
 [Unreleased]: https://github.com/giantswarm/k8scloudconfig/compare/v15.0.1...HEAD
 [15.0.1]: https://github.com/giantswarm/k8scloudconfig/compare/v15.0.0...v15.0.1
-[15.0.0]: https://github.com/giantswarm/k8scloudconfig/compare/v14.5.2...v15.0.0
+[15.0.0]: https://github.com/giantswarm/k8scloudconfig/compare/v14.6.0...v15.0.0
+[14.6.0]: https://github.com/giantswarm/k8scloudconfig/compare/v14.5.2...v14.6.0
 [14.5.2]: https://github.com/giantswarm/k8scloudconfig/compare/v14.5.1...v14.5.2
 [14.5.1]: https://github.com/giantswarm/k8scloudconfig/compare/v14.5.0...v14.5.1
 [14.5.0]: https://github.com/giantswarm/k8scloudconfig/compare/v14.4.0...v14.5.0

--- a/files/manifests/k8s-api-server.yaml.tmpl
+++ b/files/manifests/k8s-api-server.yaml.tmpl
@@ -76,7 +76,14 @@ spec:
     - --service-account-issuer=https://{{.Cluster.Kubernetes.API.Domain}}
     - --service-account-jwks-uri=https://{{.Cluster.Kubernetes.API.Domain}}/openid/v1/jwks
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
+    {{ if ne "" .Kubernetes.Apiserver.ServiceAccountKeyFilePath -}}
+    - --service-account-key-file={{ .Kubernetes.Apiserver.ServiceAccountKeyFilePath }}
+    {{ end -}}
+    {{ if eq "" .Kubernetes.Apiserver.ServiceAccountSigningKeyFilePath -}}
     - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-key.pem
+    {{ else -}}
+    - --service-account-signing-key-file={{ .Kubernetes.Apiserver.ServiceAccountSigningKeyFilePath }}
+    {{ end -}}
     - --proxy-client-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
     - --proxy-client-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --max-requests-inflight=${MAX_REQUESTS_INFLIGHT}

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -54,8 +54,6 @@ type Params struct {
 	Files          Files
 	// Container images used in the cloud-config templates
 	Images Images
-	// IAM Roles for Service Account key files.
-	IrsaSAKeyArgs []string
 	// Kubernetes components allow the passing of extra `docker run` and
 	// `command` arguments to image commands. This allows, for example,
 	// the addition of cloud provider extensions.
@@ -126,6 +124,12 @@ type KubernetesDockerOptions struct {
 type KubernetesPodOptions struct {
 	HostExtraMounts  []KubernetesPodOptionsHostMount
 	CommandExtraArgs []string
+	// ServiceAccountKeyFilePath is the path to the file to be used as `--service-account-key-file` in api server flags.
+	// If left empty the default value '/etc/kubernetes/ssl/service-account-key.pem' is used
+	ServiceAccountKeyFilePath string
+	// ServiceAccountSigningKeyFilePath is the path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key.
+	// If left empty the default value '/etc/kubernetes/ssl/service-account-key.pem' is used
+	ServiceAccountSigningKeyFilePath string
 }
 
 type KubernetesPodOptionsHostMount struct {


### PR DESCRIPTION
Backport of fix released in 14.6.0 to v15

This PR removes IRSA-specific flags and use generic flags for apiserver config regarding service accounts

## Checklist

- [x] Update changelog in CHANGELOG.md.
