### PR TITLE
Add registry mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing registry mirror to containerd config.
+
 ## [15.1.1] - 2022-11-03
 
 ### Fixed

--- a/files/conf/containerd-config.toml
+++ b/files/conf/containerd-config.toml
@@ -35,3 +35,8 @@ SystemdCgroup = {{ if .ForceCGroupsV1 }}false{{else}}true{{end}}
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{ .Images.Pause }}"
+
+{{- if gt (len .RegistryMirrors) 0 }}
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+endpoint = ["{{index .RegistryMirrors 0}}"]
+{{- end }}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/24615

We currently missing to set the registry mirror for workload clusters.

The registry mirrors is an array which comes from our config repo, https://github.com/giantswarm/config/blob/main/default/config.yaml#L7.

We should pick the first item to add this into our containerd configuration.
I double checked it on all installations, our China installations won't include this (we overwrite an empty array in those cases).


## Checklist

- [x] Update changelog in CHANGELOG.md.