### PR TITLE
Label master nodes with node-role.kubernetes.io/control-plane 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Label master nodes with node-role.kubernetes.io/control-plane to comply with kubeadm/CAPI.
+
 ## [15.2.0] - 2022-11-24
 
 ### Added

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -392,6 +392,7 @@ systemd:
         while [ "$(kubectl get nodes $(hostname | tr '[:upper:]' '[:lower:]')| wc -l)" -lt "1" ]; do echo "Waiting for healthy k8s" && sleep 20s;done; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/master=""; \
         kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') kubernetes.io/role=master; \
+        kubectl label nodes --overwrite $(hostname | tr '[:upper:]' '[:lower:]') node-role.kubernetes.io/control-plane=""; \
         for l in $(echo "{{.Cluster.Kubernetes.Kubelet.Labels}}" | tr "," " "); do \
             kubectl label nodes --overwrite $(hostname | tr "[:upper:]" "[:lower:]") $l; \
         done'


### PR DESCRIPTION
to comply with kubeadm/CAPI.

## Checklist

- [x] Update changelog in CHANGELOG.md.
