### PR TITLE
Fix apiserver requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Lower apiserver's cpu request to be 1/2 of the available CPUs in the VM.
+
 ## [15.3.0] - 2022-11-29
 
 ### Changed

--- a/files/conf/setup-apiserver-environment
+++ b/files/conf/setup-apiserver-environment
@@ -22,5 +22,7 @@ echo "MAX_REQUESTS_INFLIGHT=$((dedicated / 1000 * 200 * 2 / 3))" >$env_file
 echo "MAX_MUTATING_REQUESTS_INFLIGHT=$((dedicated / 1000 * 200 * 1 / 3 ))" >>$env_file
 echo "CPU_LIMIT=${dedicated}m" >>$env_file
 echo "MEMORY_LIMIT=$((memory * 3 / 4))Gi" >>$env_file
-echo "CPU_REQUEST=$((cpus / 2))m" >>$env_file
+
+# We request 1/3 of the available CPUs and 1/2 of the system memory just for api server.
+echo "CPU_REQUEST=$((cpus / 3))m" >>$env_file
 echo "MEMORY_REQUEST=$((memory / 2))Gi" >>$env_file

--- a/files/conf/setup-apiserver-environment
+++ b/files/conf/setup-apiserver-environment
@@ -7,11 +7,20 @@ memory="$(awk '/MemTotal/ { printf "%d \n", $2/1024/1024 }' /proc/meminfo)"
 declare -i cpus
 declare -i memory
 
+# convert to millicores
+cpus=$((cpus*1000))
+
+# subtract dedicated millicores (see 'systemReserved' and 'kubeReserved' fields in the kubelet config file)
+cpus=$((cpus-600))
+
+# we dedicate 3/4 of all millicores to the api server
 dedicated=$((cpus * 3 / 4))
 
-echo "MAX_REQUESTS_INFLIGHT=$((dedicated * 200 * 2 / 3))" >$env_file
-echo "MAX_MUTATING_REQUESTS_INFLIGHT=$((dedicated * 200 * 1 / 3))" >>$env_file
-echo "CPU_LIMIT=${dedicated}" >>$env_file
+# for every core we have dedicated to api server we allow 200 requests for fairness.
+# 1/3 of such number is for mutating requests, 2/3 are for all requests.
+echo "MAX_REQUESTS_INFLIGHT=$((dedicated / 1000 * 200 * 2 / 3))" >$env_file
+echo "MAX_MUTATING_REQUESTS_INFLIGHT=$((dedicated / 1000 * 200 * 1 / 3 ))" >>$env_file
+echo "CPU_LIMIT=${dedicated}m" >>$env_file
 echo "MEMORY_LIMIT=$((memory * 3 / 4))Gi" >>$env_file
-echo "CPU_REQUEST=$((cpus / 2))" >>$env_file
+echo "CPU_REQUEST=$((cpus / 2))m" >>$env_file
 echo "MEMORY_REQUEST=$((memory / 2))Gi" >>$env_file


### PR DESCRIPTION
The previous strategy we used to allocate memory request for API server static pod was too aggressive.
On azure, that left not enough room for pods to be scheduled in master nodes and lead to broken clusters.

This PR changes how we calculate requests and limits for API server pod and clarifies the reasoning behind the choice.

Tradeoff: fairness limits will be lower on the same hardware

## Checklist

- [x] Update changelog in CHANGELOG.md.
