### PR TITLE
Use authentication when pulling docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Add Docker token to avoid rate limits for pulling images.
+
 ## [15.4.3] - 2023-01-19
 
 ### Added

--- a/files/conf/containerd-config.toml
+++ b/files/conf/containerd-config.toml
@@ -43,3 +43,6 @@ endpoint = ["{{index .RegistryMirrors 0}}"]
 
 [plugins."io.containerd.grpc.v1.cri".registry.configs."docker.io".auth]
 auth = "{{ .DockerhubToken }}"
+
+[plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+auth = "{{ .DockerhubToken }}"

--- a/files/conf/containerd-config.toml
+++ b/files/conf/containerd-config.toml
@@ -42,4 +42,4 @@ endpoint = ["{{index .RegistryMirrors 0}}"]
 {{- end }}
 
 [plugins."io.containerd.grpc.v1.cri".registry.configs."docker.io".auth]
-auth = "{{ .DockerhubToken  }}"
+auth = "{{ .DockerhubToken }}"

--- a/files/conf/containerd-config.toml
+++ b/files/conf/containerd-config.toml
@@ -40,3 +40,6 @@ sandbox_image = "{{ .Images.Pause }}"
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
 endpoint = ["{{index .RegistryMirrors 0}}"]
 {{- end }}
+
+[plugins."io.containerd.grpc.v1.cri".registry.configs."docker.io".auth]
+auth = "{{ .DockerhubToken  }}"


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.


```
crictl -r /run/containerd/containerd.sock pull docker.io/library/alpine:latest
FATA[0002] pulling image: rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/alpine:latest": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/alpine/manifests/sha256:f271e74b17ced29b915d351685fd4644785c6d1559dd1f2d4189a5e851ef753a: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

Adding to containerd docker auth credentials

```
[plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
auth = "OMITED"

[plugins."io.containerd.grpc.v1.cri".registry.configs."docker.io".auth]
auth = "OMITED"
```

works
```
crictl -r /run/containerd/containerd.sock pull docker.io/library/alpine:latest
Image is up to date for sha256:042a816809aac8d0f7d7cacac7965782ee2ecac3f21bcf9f24b1de1a7387b769
```