### PR TITLE
Calico job improve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Improve reliability of calico CRD installer job.
+
 ## [15.4.4] - 2023-01-24
 
 ### Fixed

--- a/files/conf/k8s-addons
+++ b/files/conf/k8s-addons
@@ -91,16 +91,27 @@ kubectl delete pods -l app.kubernetes.io/name=kube-proxy -n kube-system
 {{ end }}
 
 {{ if not .DisableCalico }}
-kubectl apply -f /srv/calico-crd-installer-rbac.yaml
+# install calico CRDS
+PROXY_MANIFESTS="calico-crd-installer-rbac.yaml calico-crd-installer.yaml"
+for manifest in $PROXY_MANIFESTS
+do
+    while
+        kubectl apply -f /srv/$manifest
+        [ "$?" -ne "0" ]
+    do
+        echo "failed to apply /srv/$manifest, retrying in 5 sec"
+        sleep 5s
+    done
+done
+echo "calico CRD installer successfully applied"
 
-kubectl apply -f /srv/calico-crd-installer.yaml
-kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-crd-installer
-
-{{ if not .CalicoPolicyOnly }}
-# TODO: remove migrator once all clusters have been migrated to kubernetes datastore
-kubectl apply -f /srv/calico-datastore-migrator-pre.yaml
-kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-datastore-migrator-pre
-{{ end }}
+while
+    kubectl wait --for=condition=complete --timeout=1m -n kube-system job -lapp.kubernetes.io/name=calico-crd-installer
+    [ "$?" -ne "0" ]
+do
+    echo "Failed waiting for crd installer job to be completed, retrying in 5 sec"
+    sleep 5s
+done
 
 {{ if .CalicoPolicyOnly }}
 ## Apply Calico with network policy features only

--- a/files/k8s-resource/calico-crd-installer.yaml
+++ b/files/k8s-resource/calico-crd-installer.yaml
@@ -23,6 +23,8 @@ spec:
           effect: NoSchedule
         - key: node.cloudprovider.kubernetes.io/uninitialized
           operator: Exists
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
       restartPolicy: Never
       serviceAccountName: calico-init
   backoffLimit: 4


### PR DESCRIPTION
In k8s-addons script we deploy a job + RBAC manifest using kubectl apply.
Before this pr, we only tried once to apply those manifests and in case of error the master node provisioning was failing.

With this PR we retry the apply operation multiple times in case of error to make bootstrap more reliable

## Checklist

- [x] Update changelog in CHANGELOG.md.
