### PR TITLE
Update k8s-api-healthz.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## [15.6.0] - 2023-02-07
+
 ### Changed
 
 - Enable `CronJobTimeZone` feature gate.
@@ -1306,7 +1308,8 @@ chart-operator).
 
 ## [0.1.0]
 
-[Unreleased]: https://github.com/giantswarm/k8scloudconfig/compare/v15.5.0...HEAD
+[Unreleased]: https://github.com/giantswarm/k8scloudconfig/compare/v15.6.0...HEAD
+[15.6.0]: https://github.com/giantswarm/k8scloudconfig/compare/v15.5.0...v15.6.0
 [15.5.0]: https://github.com/giantswarm/k8scloudconfig/compare/v15.4.4...v15.5.0
 [15.4.4]: https://github.com/giantswarm/k8scloudconfig/compare/v15.4.3...v15.4.4
 [15.4.3]: https://github.com/giantswarm/k8scloudconfig/compare/v15.4.2...v15.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `--api-endpoint` flag from `k8s-api-healthz` static pod manifest as the default value 127.0.0.1 is safe to be used now.
+
 ## [15.6.0] - 2023-02-07
 
 ### Changed

--- a/files/manifests/k8s-api-healthz.yaml
+++ b/files/manifests/k8s-api-healthz.yaml
@@ -10,14 +10,8 @@ spec:
   priorityClassName: system-node-critical
   containers:
     - name: k8s-api-healthz
-      env:
-      - name: HOST_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
       command:
         - /k8s-api-healthz
-        - --api-endpoint="https://$(HOST_IP):443/healthz"
         - --etcd-cert=/etc/kubernetes/ssl/etcd/server-crt.pem
         - --etcd-key=/etc/kubernetes/ssl/etcd/server-key.pem
         - --etcd-ca-cert=/etc/kubernetes/ssl/etcd/server-ca.pem


### PR DESCRIPTION
With latest healthz version, the api flag is not ignored any more (it was a bug) and the health check fails because of tls error.
With this PR we use the flag's default value that works.

## Checklist

- [x] Update changelog in CHANGELOG.md.
