### PR TITLE
Enable `CronJobTimeZone` feature gate through feature flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enable `CronJobTimeZone` feature gate through feature flag.
+
 ## [15.6.0] - 2023-02-07
 
 ### Changed

--- a/files/config/kubelet-master.yaml.tmpl
+++ b/files/config/kubelet-master.yaml.tmpl
@@ -46,7 +46,9 @@ featureGates:
   {{- if .InTreePluginAWSUnregister }}
   InTreePluginAWSUnregister: true
   {{- end }}
+  {{- if .EnableCronJobTimeZone }}
   CronJobTimeZone: true
+  {{- end }}
 tlsCipherSuites:
   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/files/config/kubelet-worker.yaml.tmpl
+++ b/files/config/kubelet-worker.yaml.tmpl
@@ -45,7 +45,9 @@ featureGates:
   {{- if .InTreePluginAWSUnregister }}
   InTreePluginAWSUnregister: true
   {{- end }}
+  {{- if .EnableCronJobTimeZone }}
   CronJobTimeZone: true
+  {{- end }}
 tlsCipherSuites:
   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/files/manifests/k8s-api-server.yaml.tmpl
+++ b/files/manifests/k8s-api-server.yaml.tmpl
@@ -38,7 +38,7 @@ spec:
     - --profiling=false
     - --service-account-lookup=true
     - --authorization-mode=RBAC
-    - --feature-gates=TTLAfterFinished=true,CronJobTimeZone=true
+    - --feature-gates=TTLAfterFinished=true{{ if .EnableCronJobTimeZone }},CronJobTimeZone=true{{ end }}
     - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
     {{ if .ExternalCloudControllerManager -}}
     - --cloud-provider=external

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -40,9 +40,9 @@ spec:
     - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
     - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
     {{- if .InTreePluginAWSUnregister }}
-    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister=true,CronJobTimeZone=true
+    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},InTreePluginAWSUnregister=true{{ if .EnableCronJobTimeZone }},CronJobTimeZone=true{{ end }}
     {{- else }}
-    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }},CronJobTimeZone=true
+    - --feature-gates=TTLAfterFinished=true,CSIMigrationAWS={{ .EnableCSIMigrationAWS }}{{ if .EnableCronJobTimeZone }},CronJobTimeZone=true{{ end }}
     {{- end }}
     - --profiling=false
     - --root-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem

--- a/files/manifests/k8s-scheduler.yaml
+++ b/files/manifests/k8s-scheduler.yaml
@@ -24,7 +24,7 @@ spec:
     image: {{ .Images.KubeScheduler }}
     command:
     - kube-scheduler
-    - --feature-gates=TTLAfterFinished=true,CronJobTimeZone=true
+    - --feature-gates=TTLAfterFinished=true{{ if .EnableCronJobTimeZone }},CronJobTimeZone=true{{ end }}
     - --config=/etc/kubernetes/config/scheduler.yaml
     - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/scheduler.yaml
     - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/scheduler.yaml

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -19,7 +19,7 @@ type Params struct {
 	AWSCNISubnetPrefixMode bool
 	// EnableCSIMigrationAWS flag. When set to true will use in-tree EBS volumes will be migrated to CSI.
 	EnableCSIMigrationAWS bool
-	// EnableCronJobTimeZone flag. When set to true the `EnableCronJobTimeZone` will be enabled.
+	// EnableCronJobTimeZone flag. When set to true the `CronJobTimeZone` feature flag will be enabled.
 	EnableCronJobTimeZone bool
 	// force cgroups v1 on flatcar 3033.2.1 and above
 	// this configuration will do reboot to ensure kernel loaded the arguments

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -19,6 +19,8 @@ type Params struct {
 	AWSCNISubnetPrefixMode bool
 	// EnableCSIMigrationAWS flag. When set to true will use in-tree EBS volumes will be migrated to CSI.
 	EnableCSIMigrationAWS bool
+	// EnableCronJobTimeZone flag. When set to true the `EnableCronJobTimeZone` will be enabled.
+	EnableCronJobTimeZone bool
 	// force cgroups v1 on flatcar 3033.2.1 and above
 	// this configuration will do reboot to ensure kernel loaded the arguments
 	ForceCGroupsV1 bool


### PR DESCRIPTION
The `CronJobTimeZone` feature flag is only available in k8s 1.24+
This PR makes the feature flag configurable so we can bump k8scc on 1.23 clusters

## Checklist

- [x] Update changelog in CHANGELOG.md.
