### PR TITLE
Remove usage of `--logtostderr` flag that was removed upstream since …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Remove usage of `--logtostderr` flag that was removed upstream since 1.26. 
+
 ## [17.0.0] - 2023-05-16
 
 ### Removed

--- a/files/manifests/k8s-api-server.yaml.tmpl
+++ b/files/manifests/k8s-api-server.yaml.tmpl
@@ -57,7 +57,6 @@ spec:
     - --etcd-compaction-interval=0
     - --advertise-address=$(HOST_IP)
     - --runtime-config=api/all=true,scheduling.k8s.io/v1alpha1=true
-    - --logtostderr=true
     - --tls-cert-file=/etc/kubernetes/ssl/apiserver-crt.pem
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -27,7 +27,6 @@ spec:
     {{ range .Kubernetes.ControllerManager.CommandExtraArgs -}}
     - {{ . }}
     {{ end -}}
-    - --logtostderr=true
     - --v=2
     {{ if .ExternalCloudControllerManager -}}
     - --cloud-provider=external

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -343,7 +343,6 @@ systemd:
         --config=/etc/kubernetes/config/kubelet.yaml \
         --container-runtime=remote \
         --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
-        --logtostderr=true \
         {{ if .ExternalCloudControllerManager -}}
         --cloud-provider=external \
         {{ else -}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -222,7 +222,6 @@ systemd:
         --config=/etc/kubernetes/config/kubelet.yaml \
         --container-runtime=remote \
         --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
-        --logtostderr=true \
         {{ if .ExternalCloudControllerManager -}}
         --cloud-provider=external \
         {{ else -}}


### PR DESCRIPTION
…1.26.

## Checklist

- [x] Update changelog in CHANGELOG.md.
