### PR TITLE
Remove CSIMigration feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Removed
 
 - Remove usage of `--logtostderr` flag that was removed upstream since 1.26. 
+- Remove CSIMigration feature (removed in k8s 1.25).
 
 ## [17.0.0] - 2023-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Removed
 
 - Remove usage of `--logtostderr` flag that was removed upstream since 1.26. 
-- Remove CSIMigration feature (removed in k8s 1.25).
+- Remove CSIMigration feature flag (enabled by default since 1.23).
 
 ## [17.0.0] - 2023-05-16
 

--- a/files/config/kubelet-master.yaml.tmpl
+++ b/files/config/kubelet-master.yaml.tmpl
@@ -39,9 +39,6 @@ authentication:
 authorization:
   mode: AlwaysAllow # Defaults to webhook as of 1.10
 featureGates:
-  {{- if .EnableCSIMigrationAWS }}
-  CSIMigrationAWS: true
-  {{- end }}
   {{- if .InTreePluginAWSUnregister }}
   InTreePluginAWSUnregister: true
   {{- end }}

--- a/files/config/kubelet-worker.yaml.tmpl
+++ b/files/config/kubelet-worker.yaml.tmpl
@@ -38,9 +38,6 @@ authentication:
 authorization:
   mode: AlwaysAllow # Defaults to webhook as of 1.10
 featureGates:
-  {{- if .EnableCSIMigrationAWS }}
-  CSIMigrationAWS: true
-  {{- end }}
   {{- if .InTreePluginAWSUnregister }}
   InTreePluginAWSUnregister: true
   {{- end }}

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -17,8 +17,6 @@ type Params struct {
 	EnableAWSCNI bool
 	// AWSCNISubnetPrefixMode set to true when cluster is using Subnet Prefix mode, will remove pod limit per node.
 	AWSCNISubnetPrefixMode bool
-	// EnableCSIMigrationAWS flag. When set to true will use in-tree EBS volumes will be migrated to CSI.
-	EnableCSIMigrationAWS bool
 	// EnableCronJobTimeZone flag. When set to true the `CronJobTimeZone` feature flag will be enabled.
 	EnableCronJobTimeZone bool
 	// force cgroups v1 on flatcar 3033.2.1 and above


### PR DESCRIPTION
This feature flag is enabled by default with > k8s 1.23.

Issue: https://github.com/giantswarm/roadmap/issues/2536


See https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/
## Checklist

- [x] Update changelog in CHANGELOG.md.