### PR TITLE
Add support for changing value of `controller-manager` `--terminated-pod-gc-threshold` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added support for changing `controller-manager` `terminated-pod-gc-threshold` flag
+  - Remove hardcoded value of `10` and change default value to `125` ( 1% of the upstream default of `12500` )
+
+
 ### Removed
 
 - Remove etcd check in k8s-addons.

--- a/files/manifests/k8s-controller-manager.yaml
+++ b/files/manifests/k8s-controller-manager.yaml
@@ -33,7 +33,7 @@ spec:
     {{ else -}}
     - --cloud-provider={{.Cluster.Kubernetes.CloudProvider}}
     {{ end -}}
-    - --terminated-pod-gc-threshold=10
+    - --terminated-pod-gc-threshold={{if eq .ControllerManagerTerminatedPodGcThreshold 0}}125{{else}}{{.ControllerManagerTerminatedPodGcThreshold}}{{end}}
     - --use-service-account-credentials=true
     - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
     - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml

--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -17,6 +17,8 @@ type Params struct {
 	EnableAWSCNI bool
 	// AWSCNISubnetPrefixMode set to true when cluster is using Subnet Prefix mode, will remove pod limit per node.
 	AWSCNISubnetPrefixMode bool
+	// ControllerManagerTerminatedPodGcThreshold flag. Set the value to use for ControllerManager terminated-pod-gc-threshold flag
+	ControllerManagerTerminatedPodGcThreshold int
 	// EnableCronJobTimeZone flag. When set to true the `CronJobTimeZone` feature flag will be enabled.
 	EnableCronJobTimeZone bool
 	// force cgroups v1 on flatcar 3033.2.1 and above


### PR DESCRIPTION
Also change default value from hardcoded `10` to `125` which is 1% of the upstream default of `12500`

Towards https://github.com/giantswarm/klingel/issues/91

for **v16.x.x** a branch from `v16.3.0` was created and the same diff applied in https://github.com/giantswarm/k8scloudconfig/tree/allow-customizing-terminated-pod-gc-threshold-v16 

## Checklist

- [ ] Update changelog in CHANGELOG.md.
