### PR TITLE
Enable auditd systemd unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Enable auditd unit.
+
 ## [17.2.0] - 2023-07-04
 
 ### Added
 
 - Added support for changing `controller-manager` `terminated-pod-gc-threshold` flag
   - Remove hardcoded value of `10` and change default value to `125` ( 1% of the upstream default of `12500` )
-
 
 ### Removed
 

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -38,6 +38,8 @@ systemd:
       contents: |
         [Service]
         ExecStartPre=/bin/bash -c "while [ ! -f /etc/audit/rules.d/10-docker.rules ]; do echo 'Waiting for /etc/audit/rules.d/10-docker.rules to be written' && sleep 1; done"
+  - name: auditd.service
+    enabled: true
   {{range .Extension.Units}}
   - name: {{.Metadata.Name}}
     enabled: {{.Metadata.Enabled}}

--- a/pkg/template/worker_template.go
+++ b/pkg/template/worker_template.go
@@ -31,6 +31,8 @@ systemd:
       Requires=-.slice
       After=-.slice
   # End - manual management for cgroup structure
+  - name: auditd.service
+    enabled: true
   {{range .Extension.Units}}
   - name: {{.Metadata.Name}}
     enabled: {{.Metadata.Enabled}}
@@ -438,7 +440,7 @@ storage:
       contents:
         source: "data:text/plain;charset=utf-8;base64,{{  index .Files "conf/k8s-extract" }}"
 
-    - path : /etc/audit/rules.d/99-default.rules
+    - path: /etc/audit/rules.d/99-default.rules
       overwrite: true
       filesystem: root
       mode: 420


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24992 this PR enables the auditd systemd unit so customers can have audit logs until teleport is out there

## Checklist

- [x] Update changelog in CHANGELOG.md.
