### PR TITLE
Update containerd-config.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Enable auditd unit.
 
+### Changed
+
+- Changed plugin key containerd.runtime.v1.linux in containerd configuration for release 1.7.x.
+
+
 ## [17.2.0] - 2023-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Changed plugin key containerd.runtime.v1.linux in containerd configuration for release 1.7.x.
 
-
 ## [17.2.0] - 2023-07-04
 
 ### Added

--- a/files/conf/containerd-config.toml
+++ b/files/conf/containerd-config.toml
@@ -18,7 +18,7 @@ uid = 0
 # socket gid
 gid = 0
 
-[plugins."containerd.runtime.v1.linux"]
+[plugins."io.containerd.runtime.v1.linux"]
 # shim binary name/path
 shim = "containerd-shim"
 # runtime binary name/path


### PR DESCRIPTION
This needs to change with Kernel 6.x.

It will break loading the configuration.

```
containerd: failed to load TOML from /etc/containerd/config.toml: invalid plugin key URI "containerd.runtime.v1.linux" expect io.containerd.x.vxInvalid 
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
