### PR TITLE
Remove ineffective replace lines from `go.sum`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,12 +37,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace (
-	github.com/coreos/etcd v3.3.10+incompatible => github.com/coreos/etcd v3.3.25+incompatible
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
-	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
-	github.com/gorilla/websocket v1.4.0 => github.com/gorilla/websocket v1.4.2
-	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.18.0
-	golang.org/x/text => golang.org/x/text v0.14.0
-	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.0.4
-)
+replace golang.org/x/text => golang.org/x/text v0.14.0


### PR DESCRIPTION
Removing `replace` lines from go.sum that had no effect as the dependencies are not used.