### PR TITLE
Added random fixed delay to etcd defrag timer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Added random fixed delay to etcd defragmentation timer.
+
 ## [18.0.0] - 2024-01-16
 
 ### Removed

--- a/pkg/template/master_template.go
+++ b/pkg/template/master_template.go
@@ -289,6 +289,8 @@ systemd:
       Description=Execute etcd3-defragmentation every day at 3.30AM UTC
       [Timer]
       OnCalendar=hourly
+      RandomizedDelaySec=55m
+      FixedRandomDelay=true
       [Install]
       WantedBy=multi-user.target
   - name: k8s-extract.service


### PR DESCRIPTION
Adds a random, fixed delay to etcd defragmentation service start to prevent them being synchronized.

Towards https://github.com/giantswarm/giantswarm/issues/29868

CAPI change in cluster chart: https://github.com/giantswarm/cluster/pull/107


## Checklist

- [x] Update changelog in CHANGELOG.md.
